### PR TITLE
Extended section properties

### DIFF
--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -59,9 +59,10 @@ namespace BH.Adapter.RFEM
 
                     if (!m_sectionDict.TryGetValue(member.StartCrossSectionNo, out sectionProperty))
                     {
-                        rf.CrossSection rfSection = modelData.GetCrossSection(member.StartCrossSectionNo, rf.ItemAt.AtNo).GetData();
+                        rf.ICrossSection rfISection = modelData.GetCrossSection(member.StartCrossSectionNo, rf.ItemAt.AtNo);
+                        rf.CrossSection rfSection = rfISection.GetData();
                         rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                        sectionProperty = rfSection.FromRFEM(rfMat);
+                        sectionProperty = rfISection.FromRFEM(rfMat);
                         m_sectionDict.Add(member.StartCrossSectionNo, sectionProperty);
                     }
 
@@ -78,9 +79,10 @@ namespace BH.Adapter.RFEM
 
                     if (!m_sectionDict.TryGetValue(member.StartCrossSectionNo, out sectionProperty))
                     {
-                        rf.CrossSection rfSection = modelData.GetCrossSection(member.StartCrossSectionNo, rf.ItemAt.AtNo).GetData();
+                        rf.ICrossSection rfISection = modelData.GetCrossSection(member.StartCrossSectionNo, rf.ItemAt.AtNo);
+                        rf.CrossSection rfSection = rfISection.GetData();
                         rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                        sectionProperty = rfSection.FromRFEM(rfMat);
+                        sectionProperty = rfISection.FromRFEM(rfMat);
                         m_sectionDict.Add(member.StartCrossSectionNo, sectionProperty);
                     }
 

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -90,7 +90,6 @@ namespace BH.Adapter.RFEM
                 }
             }
 
-            AppUnlock();
 
             return barList;
         }

--- a/RFEM_Adapter/CRUD/Read/Constraint.cs
+++ b/RFEM_Adapter/CRUD/Read/Constraint.cs
@@ -60,7 +60,6 @@ namespace BH.Adapter.RFEM
                 }
             }
 
-            AppUnlock();
 
             return constraintList;
         }

--- a/RFEM_Adapter/CRUD/Read/Material.cs
+++ b/RFEM_Adapter/CRUD/Read/Material.cs
@@ -68,7 +68,6 @@ namespace BH.Adapter.RFEM
                 }
             }
 
-            AppUnlock();
 
             return materialList;
         }

--- a/RFEM_Adapter/CRUD/Read/Node.cs
+++ b/RFEM_Adapter/CRUD/Read/Node.cs
@@ -64,7 +64,6 @@ namespace BH.Adapter.RFEM
                 }
             }
 
-            AppUnlock();
 
             return nodeList;
         }

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -57,7 +57,8 @@ namespace BH.Adapter.RFEM
                 foreach (rf.CrossSection rfSection in modelData.GetCrossSections())
                 {
                     rf.Material rfMaterial = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                    ISectionProperty section = rfSection.FromRFEM(rfMaterial);
+                    rf.ICrossSection rfISection = modelData.GetCrossSection(rfSection.No, rf.ItemAt.AtNo);
+                    ISectionProperty section = rfISection.FromRFEM(rfMaterial);
 
                     sectionPropList.Add(section);
 
@@ -72,9 +73,10 @@ namespace BH.Adapter.RFEM
             {
                 foreach (string id in ids)
                 {
-                    rf.CrossSection rfSection = modelData.GetCrossSection(Int32.Parse(id), rf.ItemAt.AtNo).GetData();
+                    rf.ICrossSection rfISection = modelData.GetCrossSection(Int32.Parse(id), rf.ItemAt.AtNo);
+                    rf.CrossSection rfSection = rfISection.GetData();
                     rf.Material rfMaterial = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                    sectionPropList.Add(rfSection.FromRFEM(rfMaterial));
+                    sectionPropList.Add(rfISection.FromRFEM(rfMaterial));
                 }
             }
 

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -80,7 +80,6 @@ namespace BH.Adapter.RFEM
                 }
             }
 
-            AppUnlock();
 
             return sectionPropList;
         }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.RFEM
         public static IMaterialFragment FromRFEM(this rf.Material material)
         {
             IMaterialFragment bhMaterial;
-            MaterialType matType = GetMaterialTypeFromString(material.get)
+            MaterialType matType = GetMaterialTypeFromString(material.TextID);
 
             if (material.ModelType == rf.MaterialModelType.IsotropicLinearElasticType)
             {

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -42,6 +42,7 @@ namespace BH.Adapter.RFEM
         public static IMaterialFragment FromRFEM(this rf.Material material)
         {
             IMaterialFragment bhMaterial;
+            MaterialType matType = GetMaterialTypeFromString(material.get)
 
             if (material.ModelType == rf.MaterialModelType.IsotropicLinearElasticType)
             {

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -30,6 +30,7 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
+using BH.Engine.RFEM;
 
 namespace BH.Adapter.RFEM
 {
@@ -41,12 +42,11 @@ namespace BH.Adapter.RFEM
 
         public static IMaterialFragment FromRFEM(this rf.Material material)
         {
-            //NameID | Steel S 235@TypeID | STEEL@StandardID | DIN EN 1993 - 1 - 1 - 10
             IMaterialFragment bhMaterial = null;
 
             string[] stringArr = material.TextID.Split('@');
-            MaterialType matType = GetMaterialTypeFromString(stringArr[1]);
-            string matName = stringArr[0].Split('|')[1];
+            MaterialType matType = Query.GetMaterialType(material);
+            string matName = Query.GetMaterialName(material);
 
             switch (matType)
             {
@@ -76,32 +76,6 @@ namespace BH.Adapter.RFEM
             }
 
             return bhMaterial;
-        }
-
-        private static MaterialType GetMaterialTypeFromString(string RFEMTypeID)
-        {
-            switch (RFEMTypeID)//this should use the Query namespace !!!
-            {
-                case "TypeID|STEEL":
-                    return MaterialType.Steel;
-                case "TypeID|ALUMINIUM":
-                    return MaterialType.Aluminium;
-                case "TypeID|CONCRETE":
-                    return MaterialType.Concrete;
-                case "TypeID|TIMBER":
-                case "TypeID|CONIFEROUS":
-                    return MaterialType.Timber;
-                case "TypeID|CABLE":
-                    return MaterialType.Cable;
-                case "TypeID|GLASS":
-                    return MaterialType.Glass;
-                case "TypeID|REBAR":
-                    return MaterialType.Rebar;
-                case "TypeID|TENDON":
-                    return MaterialType.Tendon;
-                default:
-                    return MaterialType.Undefined;
-            }
         }
 
     }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -63,5 +63,32 @@ namespace BH.Adapter.RFEM
             return bhMaterial;
         }
 
+        private static MaterialType GetMaterialTypeFromString(string RFEMTextID)
+        {
+            string[] stringArr = RFEMTextID.Split('@');
+
+            switch (stringArr[1])
+            {
+                case "TypeID|STEEL":
+                    return MaterialType.Steel;
+                case "TypeID|ALUMINIUM":
+                    return MaterialType.Aluminium;
+                case "TypeID|CONCRETE":
+                    return MaterialType.Concrete;
+                case "TypeID|TIMBER":
+                    return MaterialType.Timber;
+                case "TypeID|CABLE":
+                    return MaterialType.Cable;
+                case "TypeID|GLASS":
+                    return MaterialType.Glass;
+                case "TypeID|REBAR":
+                    return MaterialType.Rebar;
+                case "TypeID|TENDON":
+                    return MaterialType.Tendon;
+                default:
+                    return MaterialType.Undefined;
+            }
+        }
+
     }
 }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -44,6 +44,10 @@ namespace BH.Adapter.RFEM
             IMaterialFragment bhMaterial;
             MaterialType matType = GetMaterialTypeFromString(material.TextID);
 
+            string dbgTEXTID = material.TextID;
+            string dbgDESCRIBE = material.Description;
+            string dbgMODELTYPE = material.ModelType.ToString();
+
             if (material.ModelType == rf.MaterialModelType.IsotropicLinearElasticType)
             {
                 bhMaterial = Engine.Structure.Create.Steel("S355 - I am just for testing");

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -29,7 +29,7 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
-using BH.oM.Geometry.ShapeProfiles:
+using BH.oM.Geometry.ShapeProfiles;
 using BH.Engine.Structure;
 using BH.Engine.RFEM;
 using BH.oM.Physical;
@@ -64,7 +64,7 @@ namespace BH.Adapter.RFEM
 
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
-            IProfile profile = GetSectionProfile(sectionName, sectionDBProps);
+            IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
             
             switch (materialType)
             {

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.RFEM
             switch (materialType)
             {
                 case MaterialType.Aluminium:
-                    //AluminiumSection aluSection = new AluminiumSection();
+                    AluminiumSection aluSection = new AluminiumSection();
                     //return aluSection;
                     return null;
 
@@ -85,7 +85,7 @@ namespace BH.Adapter.RFEM
                 case MaterialType.Undefined:
                     return null;
                 default:
-                    Engine.Reflection.Compute.RecordError("dont know how to make" + rfSectionProperty.TextID);
+                    Engine.Reflection.Compute.RecordError("Don't know how to make" + rfSectionProperty.TextID);
                     return null;
             }
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -47,29 +47,48 @@ namespace BH.Adapter.RFEM
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
 
-            if (materialType == MaterialType.Steel)
+            switch (materialType)
             {
-                ExplicitSection section = new ExplicitSection();
-                
-                section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
-                //section.Material = Structure.Create.Steel("default steel");
-                section.Material = rfMaterial.FromRFEM();
-                section.Name = rfSectionProperty.TextID;
+                case MaterialType.Aluminium:
+                    //AluminiumSection aluSection = new AluminiumSection();
+                    //return aluSection;
+                    return null;
 
-                section.Area = rfSectionProperty.AxialArea;
-                section.J = rfSectionProperty.TorsionMoment;
-                section.Asy = rfSectionProperty.ShearAreaY;
-                section.Asz = rfSectionProperty.ShearAreaZ;
-                section.Iy = rfSectionProperty.BendingMomentY;
-                section.Iz = rfSectionProperty.BendingMomentZ;
 
-                return section;
+                case MaterialType.Steel:
+                    ExplicitSection section = new ExplicitSection();
+                    section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
+                    //section.Material = Structure.Create.Steel("default steel");
+                    section.Material = rfMaterial.FromRFEM();
+                    section.Name = rfSectionProperty.TextID;
+
+                    section.Area = rfSectionProperty.AxialArea;
+                    section.J = rfSectionProperty.TorsionMoment;
+                    section.Asy = rfSectionProperty.ShearAreaY;
+                    section.Asz = rfSectionProperty.ShearAreaZ;
+                    section.Iy = rfSectionProperty.BendingMomentY;
+                    section.Iz = rfSectionProperty.BendingMomentZ;
+
+                    return section;
+                case MaterialType.Concrete:
+                    return null;
+                case MaterialType.Timber:
+                    return null;
+                case MaterialType.Rebar:
+                    return null;
+                case MaterialType.Tendon:
+                    return null;
+                case MaterialType.Glass:
+                    return null;
+                case MaterialType.Cable:
+                    return null;
+                case MaterialType.Undefined:
+                    return null;
+                default:
+                    Engine.Reflection.Compute.RecordError("dont know how to make" + rfSectionProperty.TextID);
+                    return null;
             }
-            else
-            {
-                Engine.Reflection.Compute.RecordError("dont know how to make" + rfSectionProperty.TextID);
-                return null;
-            }
+
 
 
         }

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -33,6 +33,7 @@ using BH.Engine.Structure;
 using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
+using rf3 = Dlubal.RFEM3;
 
 namespace BH.Adapter.RFEM
 {
@@ -45,14 +46,23 @@ namespace BH.Adapter.RFEM
         public static ISectionProperty FromRFEM(this rf.ICrossSection rfISectionProperty, rf.Material rfMaterial)
         {
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
-            
+
+            // ----- TEST READING SECTIONS FROM LIBRARY -----
+            rf3.IrfDatabaseCrSc rfSectionLibrary = rfISectionProperty.GetDatabaseCrossSection() as rf3.IrfDatabaseCrSc;
+            string sectionName = rfSectionProperty.ID;
+            rf3.IrfCrossSectionDB sectionFromDB = rfSectionLibrary.rfGetCrossSection(sectionName);
+
+            int propCount = sectionFromDB.rfGetPropertyCount();
+            rf3.DB_CRSC_PROPERTY[] sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
+            sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
+
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
 
             switch (materialType)
             {
                 case MaterialType.Aluminium:
-                    AluminiumSection aluSection = new AluminiumSection();
+                    //AluminiumSection aluSection = new AluminiumSection();
                     //return aluSection;
                     return null;
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -63,53 +63,61 @@ namespace BH.Adapter.RFEM
             }
 
 
-            MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
+            //MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
+
+            IMaterialFragment materialFragment = rfMaterial.FromRFEM();
             IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
-            
-            //Create.SectionPropertyFromProfile()// this creates the right property if the right material is provided 
+
+            IGeometricalSection geoSection =  Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 
+
+            geoSection.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
+            geoSection.Name = rfSectionProperty.TextID;
+
+            return geoSection;
+
             // use IGeometricalSection to create steel, concrete and generic sections !
 
-            switch (materialType)
-            {
-                case MaterialType.Aluminium:
-                    AluminiumSection aluSection = Create.AluminiumSectionFromProfile(profile);
-                    //return aluSection;
-                    return null;
+            //switch (materialType)
+            //{
+            //    case MaterialType.Aluminium:
+            //        AluminiumSection aluSection = Create.AluminiumSectionFromProfile(profile);
+            //        //return aluSection;
+            //        return null;
 
 
-                case MaterialType.Steel:
-                    // add switch on steel section type ! ! ! ! ! 
+            //    case MaterialType.Steel:
+            //        // add switch on steel section type ! ! ! ! ! 
 
-                    ExplicitSection section = new ExplicitSection();
+            //        ExplicitSection section = new ExplicitSection();
 
-                    section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
-                    //section.Material = Structure.Create.Steel("default steel");
-                    section.Material = rfMaterial.FromRFEM();
-                    section.Name = rfSectionProperty.TextID;
-                    section.Area = rfSectionProperty.AxialArea;
-                    section.J = rfSectionProperty.TorsionMoment;
-                    section.Asy = rfSectionProperty.ShearAreaY;
-                    section.Asz = rfSectionProperty.ShearAreaZ;
-                    section.Iy = rfSectionProperty.BendingMomentY;
-                    section.Iz = rfSectionProperty.BendingMomentZ;
+            //        section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
+            //        //section.Material = Structure.Create.Steel("default steel");
+            //        section.Material = rfMaterial.FromRFEM();
+            //        section.Name = rfSectionProperty.TextID;
+            //        section.Area = rfSectionProperty.AxialArea;
+            //        section.J = rfSectionProperty.TorsionMoment;
+            //        section.Asy = rfSectionProperty.ShearAreaY;
+            //        section.Asz = rfSectionProperty.ShearAreaZ;
+            //        section.Iy = rfSectionProperty.BendingMomentY;
+            //        section.Iz = rfSectionProperty.BendingMomentZ;
 
-                    return section;
-                case MaterialType.Concrete:
-                    // add switch on profile type !!!!
-                    //Create.ConcreteSectionFromProfile()
-                    return null;
-                case MaterialType.Timber:
-                    //Create.TimberSectionFromProfile();
-                    return null;
-                case MaterialType.Rebar:
-                case MaterialType.Tendon:
-                case MaterialType.Glass:
-                case MaterialType.Cable:
-                case MaterialType.Undefined:
-                default:
-                    Engine.Reflection.Compute.RecordError("Don't know how to make" + rfSectionProperty.TextID);
-                    return null;
-            }
+            //        return section;
+            //    case MaterialType.Concrete:
+            //        // add switch on profile type !!!!
+            //        //Create.ConcreteSectionFromProfile()
+            //        return null;
+            //    case MaterialType.Timber:
+            //        //Create.TimberSectionFromProfile();
+            //        return null;
+            //    case MaterialType.Rebar:
+            //    case MaterialType.Tendon:
+            //    case MaterialType.Glass:
+            //    case MaterialType.Cable:
+            //    case MaterialType.Undefined:
+            //    default:
+            //        Engine.Reflection.Compute.RecordError("Don't know how to make" + rfSectionProperty.TextID);
+            //        return null;
+            //}
 
 
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.RFEM
                 }
                 catch
                 {
-                    Engine.Reflection.Compute.RecordWarning("Could not create " + sectionName + " from library parameters. Best guess on name will be used");
+                    Engine.Reflection.Compute.RecordWarning("Could not create section" + sectionName + " from library parameters. Best guess on name will be used");
                 }
 
             }

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -29,6 +29,7 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry.ShapeProfiles:
 using BH.Engine.Structure;
 using BH.Engine.RFEM;
 using BH.oM.Physical;
@@ -49,30 +50,35 @@ namespace BH.Adapter.RFEM
 
             // ----- TEST READING SECTIONS FROM LIBRARY -----
             string sectionName = rfSectionProperty.Description;
+            rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
             if (sectionName != "")
             {
                 object libraryObj = rfISectionProperty.GetDatabaseCrossSection();
                 rf3.IrfCrossSectionDB sectionFromDB = libraryObj as rf3.IrfCrossSectionDB;
 
                 int propCount = sectionFromDB.rfGetPropertyCount();
-                rf3.DB_CRSC_PROPERTY[] sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
+                sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
                 sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
 
             }
 
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
-
+            IProfile profile = GetSectionProfile(sectionName, sectionDBProps);
+            
             switch (materialType)
             {
                 case MaterialType.Aluminium:
-                    //AluminiumSection aluSection = new AluminiumSection();
+                    AluminiumSection aluSection = Create.AluminiumSectionFromProfile(profile);
                     //return aluSection;
                     return null;
 
 
                 case MaterialType.Steel:
+                    // add switch on steel section type ! ! ! ! ! 
+
                     ExplicitSection section = new ExplicitSection();
+                    
                     section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
                     //section.Material = Structure.Create.Steel("default steel");
                     section.Material = rfMaterial.FromRFEM();
@@ -87,19 +93,17 @@ namespace BH.Adapter.RFEM
 
                     return section;
                 case MaterialType.Concrete:
+                    // add switch on profile type !!!!
+                    //Create.ConcreteSectionFromProfile()
                     return null;
                 case MaterialType.Timber:
+                    //Create.TimberSectionFromProfile();
                     return null;
                 case MaterialType.Rebar:
-                    return null;
                 case MaterialType.Tendon:
-                    return null;
                 case MaterialType.Glass:
-                    return null;
                 case MaterialType.Cable:
-                    return null;
                 case MaterialType.Undefined:
-                    return null;
                 default:
                     Engine.Reflection.Compute.RecordError("Don't know how to make" + rfSectionProperty.TextID);
                     return null;

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -50,14 +50,23 @@ namespace BH.Adapter.RFEM
 
             string sectionName = rfSectionProperty.Description;
             rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
+            object libraryObj = null;
+
             if (sectionName != "")
             {
-                object libraryObj = rfISectionProperty.GetDatabaseCrossSection();
-                rf3.IrfCrossSectionDB sectionFromDB = libraryObj as rf3.IrfCrossSectionDB;
+                try
+                {
+                    libraryObj = rfISectionProperty.GetDatabaseCrossSection();
+                    rf3.IrfCrossSectionDB sectionFromDB = libraryObj as rf3.IrfCrossSectionDB;
 
-                int propCount = sectionFromDB.rfGetPropertyCount();
-                sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
-                sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
+                    int propCount = sectionFromDB.rfGetPropertyCount();
+                    sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
+                    sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
+                }
+                catch
+                {
+                    Engine.Reflection.Compute.RecordWarning("Could not create " + sectionName + " from library parameters. Best guess on name will be used");
+                }
 
             }
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM
         {
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
 
-            // ----- TEST READING SECTIONS FROM LIBRARY -----
+            // ----- TEST READING SECTIONS FROM RFEM LIBRARY -----
             string sectionName = rfSectionProperty.Description;
             rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
             if (sectionName != "")

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.RFEM
                 }
                 catch
                 {
-                    Engine.Reflection.Compute.RecordWarning("Could not create section" + sectionName + " from library parameters. Best guess on name will be used");
+                    Engine.Reflection.Compute.RecordWarning("Could not create section named " + sectionName + " from library parameters. Best guess on name will be used");
                 }
 
             }
@@ -73,13 +73,28 @@ namespace BH.Adapter.RFEM
 
             IMaterialFragment materialFragment = rfMaterial.FromRFEM();
             IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
+            if (profile != null)
+            {
+                IGeometricalSection geoSection = Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 
+                geoSection.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
+                geoSection.Name = rfSectionProperty.TextID;
 
-            IGeometricalSection geoSection =  Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 
-
-            geoSection.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
-            geoSection.Name = rfSectionProperty.TextID;
-
-            return geoSection;
+                return geoSection;
+            }
+            else
+            {
+                ExplicitSection expSection = new ExplicitSection();
+                expSection.Material = materialFragment;
+                expSection.Area = rfSectionProperty.AxialArea;
+                expSection.J = rfSectionProperty.TorsionMoment;
+                expSection.Asy = rfSectionProperty.ShearAreaY;
+                expSection.Asz = rfSectionProperty.ShearAreaZ;
+                expSection.Iy = rfSectionProperty.BendingMomentY;
+                expSection.Iz = rfSectionProperty.BendingMomentZ;
+                expSection.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
+                expSection.Name = rfSectionProperty.TextID;
+                return expSection;
+            }
 
 
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -48,7 +48,6 @@ namespace BH.Adapter.RFEM
         {
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
 
-            // ----- TEST READING SECTIONS FROM RFEM LIBRARY -----
             string sectionName = rfSectionProperty.Description;
             rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
             if (sectionName != "")
@@ -63,8 +62,6 @@ namespace BH.Adapter.RFEM
             }
 
 
-            //MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
-
             IMaterialFragment materialFragment = rfMaterial.FromRFEM();
             IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
 
@@ -74,50 +71,6 @@ namespace BH.Adapter.RFEM
             geoSection.Name = rfSectionProperty.TextID;
 
             return geoSection;
-
-            // use IGeometricalSection to create steel, concrete and generic sections !
-
-            //switch (materialType)
-            //{
-            //    case MaterialType.Aluminium:
-            //        AluminiumSection aluSection = Create.AluminiumSectionFromProfile(profile);
-            //        //return aluSection;
-            //        return null;
-
-
-            //    case MaterialType.Steel:
-            //        // add switch on steel section type ! ! ! ! ! 
-
-            //        ExplicitSection section = new ExplicitSection();
-
-            //        section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
-            //        //section.Material = Structure.Create.Steel("default steel");
-            //        section.Material = rfMaterial.FromRFEM();
-            //        section.Name = rfSectionProperty.TextID;
-            //        section.Area = rfSectionProperty.AxialArea;
-            //        section.J = rfSectionProperty.TorsionMoment;
-            //        section.Asy = rfSectionProperty.ShearAreaY;
-            //        section.Asz = rfSectionProperty.ShearAreaZ;
-            //        section.Iy = rfSectionProperty.BendingMomentY;
-            //        section.Iz = rfSectionProperty.BendingMomentZ;
-
-            //        return section;
-            //    case MaterialType.Concrete:
-            //        // add switch on profile type !!!!
-            //        //Create.ConcreteSectionFromProfile()
-            //        return null;
-            //    case MaterialType.Timber:
-            //        //Create.TimberSectionFromProfile();
-            //        return null;
-            //    case MaterialType.Rebar:
-            //    case MaterialType.Tendon:
-            //    case MaterialType.Glass:
-            //    case MaterialType.Cable:
-            //    case MaterialType.Undefined:
-            //    default:
-            //        Engine.Reflection.Compute.RecordError("Don't know how to make" + rfSectionProperty.TextID);
-            //        return null;
-            //}
 
 
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -42,8 +42,10 @@ namespace BH.Adapter.RFEM
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static ISectionProperty FromRFEM(this rf.CrossSection rfSectionProperty, rf.Material rfMaterial)
+        public static ISectionProperty FromRFEM(this rf.ICrossSection rfISectionProperty, rf.Material rfMaterial)
         {
+            rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
+            
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -48,13 +48,17 @@ namespace BH.Adapter.RFEM
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
 
             // ----- TEST READING SECTIONS FROM LIBRARY -----
-            rf3.IrfDatabaseCrSc rfSectionLibrary = rfISectionProperty.GetDatabaseCrossSection() as rf3.IrfDatabaseCrSc;
-            string sectionName = rfSectionProperty.ID;
-            rf3.IrfCrossSectionDB sectionFromDB = rfSectionLibrary.rfGetCrossSection(sectionName);
+            string sectionName = rfSectionProperty.Description;
+            if (sectionName != "")
+            {
+                object libraryObj = rfISectionProperty.GetDatabaseCrossSection();
+                rf3.IrfCrossSectionDB sectionFromDB = libraryObj as rf3.IrfCrossSectionDB;
 
-            int propCount = sectionFromDB.rfGetPropertyCount();
-            rf3.DB_CRSC_PROPERTY[] sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
-            sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
+                int propCount = sectionFromDB.rfGetPropertyCount();
+                rf3.DB_CRSC_PROPERTY[] sectionDBProps = new rf3.DB_CRSC_PROPERTY[propCount];
+                sectionFromDB.rfGetPropertyArrAll(propCount, sectionDBProps);
+
+            }
 
 
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -66,6 +66,9 @@ namespace BH.Adapter.RFEM
             MaterialType materialType = Engine.RFEM.Query.GetMaterialType(rfMaterial);
             IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
             
+            //Create.SectionPropertyFromProfile()// this creates the right property if the right material is provided 
+            // use IGeometricalSection to create steel, concrete and generic sections !
+
             switch (materialType)
             {
                 case MaterialType.Aluminium:
@@ -78,12 +81,11 @@ namespace BH.Adapter.RFEM
                     // add switch on steel section type ! ! ! ! ! 
 
                     ExplicitSection section = new ExplicitSection();
-                    
+
                     section.CustomData[BH.Adapter.RFEM.Convert.AdapterIdName] = rfSectionProperty.No;
                     //section.Material = Structure.Create.Steel("default steel");
                     section.Material = rfMaterial.FromRFEM();
                     section.Name = rfSectionProperty.TextID;
-
                     section.Area = rfSectionProperty.AxialArea;
                     section.J = rfSectionProperty.TorsionMoment;
                     section.Asy = rfSectionProperty.ShearAreaY;

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -40,6 +40,8 @@ namespace BH.Adapter.RFEM
 
         public static rf.Material ToRFEM(this IMaterialFragment materialFragment, int materialId)
         {
+            //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
+
             rf.Material rfMaterial = new rf.Material();
             rfMaterial.No = materialId;
             rfMaterial.Description = materialFragment.Name;
@@ -51,7 +53,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
-
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | ALUMINIUM" + "@StandardID | No norm set!";
             }
             else if (materialFragment.GetType() == typeof(Steel))
             {
@@ -59,7 +61,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
-
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
             }
             else if (materialFragment.GetType() == typeof(Concrete))
             {
@@ -67,6 +69,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | CONCRETE" + "@StandardID | No norm set!";
 
             }
             else if (materialFragment.GetType() == typeof(GenericIsotropicMaterial))
@@ -75,6 +78,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
 
             }
             else if (materialFragment.GetType() == typeof(Timber))
@@ -84,6 +88,8 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
+
             }
             else if (materialFragment.GetType() == typeof(GenericOrthotropicMaterial))
             {
@@ -91,6 +97,8 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
+
             }
             else
             {
@@ -99,6 +107,8 @@ namespace BH.Adapter.RFEM
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
                 Engine.Reflection.Compute.RecordWarning("Cannot make " + materialFragment.Name + ". Replaced with standard steel");
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+
             }
 
             return rfMaterial;

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -45,17 +45,59 @@ namespace BH.Adapter.RFEM
             rfMaterial.Description = materialFragment.Name;
             rfMaterial.SpecificWeight = materialFragment.Density * 10; //translate from kg/m3 to kN/m3
 
-            if (materialFragment is IIsotropic)
+            if (materialFragment.GetType() == typeof(Aluminium))
             {
                 IIsotropic material = materialFragment as IIsotropic;
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
-                rfMaterial.ModelType = rf.MaterialModelType.IsotropicLinearElasticType;//--consider other types depending on analysis type
+
+            }
+            else if (materialFragment.GetType() == typeof(Steel))
+            {
+                IIsotropic material = materialFragment as IIsotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
+                rfMaterial.PoissonRatio = material.PoissonsRatio;
+                rfMaterial.ElasticityModulus = material.YoungsModulus;
+
+            }
+            else if (materialFragment.GetType() == typeof(Concrete))
+            {
+                IIsotropic material = materialFragment as IIsotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
+                rfMaterial.PoissonRatio = material.PoissonsRatio;
+                rfMaterial.ElasticityModulus = material.YoungsModulus;
+
+            }
+            else if (materialFragment.GetType() == typeof(GenericIsotropicMaterial))
+            {
+                IIsotropic material = materialFragment as IIsotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
+                rfMaterial.PoissonRatio = material.PoissonsRatio;
+                rfMaterial.ElasticityModulus = material.YoungsModulus;
+
+            }
+            else if (materialFragment.GetType() == typeof(Timber))
+            {
+                IOrthotropic material = materialFragment as IOrthotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
+                rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
+                rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
+            }
+            else if (materialFragment.GetType() == typeof(GenericOrthotropicMaterial))
+            {
+                IOrthotropic material = materialFragment as IOrthotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
+                rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
+                rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
             }
             else
             {
-                Engine.Reflection.Compute.RecordWarning("Upsie Daisy! Isotropic materials only for now! cannot make " + materialFragment.Name);
+                IIsotropic material = materialFragment as IIsotropic;
+                rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
+                rfMaterial.PoissonRatio = material.PoissonsRatio;
+                rfMaterial.ElasticityModulus = material.YoungsModulus;
+                Engine.Reflection.Compute.RecordWarning("Cannot make " + materialFragment.Name + ". Replaced with standard steel");
             }
 
             return rfMaterial;

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -79,6 +79,7 @@ namespace BH.Adapter.RFEM
             }
             else if (materialFragment.GetType() == typeof(Timber))
             {
+                //TODO: this looks like orthotropic is turned into isotropic !!!
                 IOrthotropic material = materialFragment as IOrthotropic;
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -90,14 +90,14 @@ namespace BH.Adapter.RFEM
                             name = s.SectionProfile.Shape.ToString();
                         break;
                     default:
-                        Engine.Reflection.Compute.RecordWarning("No name provided for section No:" + sectionPropertyId.ToString() + ". Name set to Id number.);
+                        Engine.Reflection.Compute.RecordWarning("No name provided for section No:" + sectionPropertyId.ToString() + ". Name set to Id number.");
                         name = "section id: " + sectionPropertyId.ToString();
                         break;
                 }
             }
 
             rfSectionProperty.Description = name;
-            rfSectionProperty.TextID = "NameID | " + name + "@TypeID | " + sectionProperty.Material.ToString() + "@StandardID | DIN EN 1993 - 1 - 1 - 10";
+            rfSectionProperty.TextID = name;
 
             return rfSectionProperty;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -41,10 +41,9 @@ namespace BH.Adapter.RFEM
         public static rf.CrossSection ToRFEM(this ISectionProperty sectionProperty, int sectionPropertyId, int materialId)
         {
             rf.CrossSection rfSectionProperty = new rf.CrossSection();
+            string name;
             rfSectionProperty.No = sectionPropertyId;
             rfSectionProperty.MaterialNo = materialId;
-            rfSectionProperty.TextID = sectionProperty.Name;
-            rfSectionProperty.Description = sectionProperty.Name + " | " + "no standard/norm";
             rfSectionProperty.AxialArea = sectionProperty.Area;
             rfSectionProperty.TorsionMoment = sectionProperty.J;
             rfSectionProperty.ShearAreaY = sectionProperty.Asy;
@@ -52,25 +51,53 @@ namespace BH.Adapter.RFEM
             rfSectionProperty.BendingMomentY = sectionProperty.Iy;
             rfSectionProperty.BendingMomentZ = sectionProperty.Iz;
 
-
-
-            if (sectionProperty is SteelSection)
+            if(sectionProperty.Name != "")
             {
-                SteelSection steelSection = sectionProperty as SteelSection;
-
-            }
-            else if (sectionProperty is ConcreteSection)
-            {
-                Engine.Reflection.Compute.RecordWarning("my responses are limited. I only speak steel sections at the moment. I dont know: " + sectionProperty.Name);
-            }
-            else if (sectionProperty is ExplicitSection)
-            {
-                Engine.Reflection.Compute.RecordWarning("my responses are limited. I only speak steel sections at the moment. I dont know: " + sectionProperty.Name);
+                name = sectionProperty.Name;
             }
             else
             {
-                Engine.Reflection.Compute.RecordWarning("my responses are limited. I only speak steel sections at the moment. I dont know: " + sectionProperty.Name);
+                switch (sectionProperty)
+                {
+                    case SteelSection s:
+                        if (s.SectionProfile.Name != "")
+                            name = s.SectionProfile.Name;
+                        else
+                            name = s.SectionProfile.Shape.ToString();
+                        break;
+                    case AluminiumSection s:
+                        if (s.SectionProfile.Name != "")
+                            name = s.SectionProfile.Name;
+                        else
+                            name = s.SectionProfile.Shape.ToString();
+                        break;
+                    case GenericSection s:
+                        if (s.SectionProfile.Name != "")
+                            name = s.SectionProfile.Name;
+                        else
+                            name = s.SectionProfile.Shape.ToString();
+                        break;
+                    case TimberSection s:
+                        if (s.SectionProfile.Name != "")
+                            name = s.SectionProfile.Name;
+                        else
+                            name = s.SectionProfile.Shape.ToString();
+                        break;
+                    case ConcreteSection s:
+                        if (s.SectionProfile.Name != "")
+                            name = s.SectionProfile.Name;
+                        else
+                            name = s.SectionProfile.Shape.ToString();
+                        break;
+                    default:
+                        Engine.Reflection.Compute.RecordWarning("No name provided for section No:" + sectionPropertyId.ToString() + ". Name set to Id number.);
+                        name = "section id: " + sectionPropertyId.ToString();
+                        break;
+                }
             }
+
+            rfSectionProperty.Description = name;
+            rfSectionProperty.TextID = "NameID | " + name + "@TypeID | " + sectionProperty.Material.ToString() + "@StandardID | DIN EN 1993 - 1 - 1 - 10";
 
             return rfSectionProperty;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -53,6 +53,7 @@ namespace BH.Adapter.RFEM
             rfSectionProperty.BendingMomentZ = sectionProperty.Iz;
 
 
+
             if (sectionProperty is SteelSection)
             {
                 SteelSection steelSection = sectionProperty as SteelSection;

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -113,9 +113,12 @@ namespace BH.Engine.RFEM
 
         public static string GetMaterialName(rf.Material rfMaterial)
         {
+            string materialName;
             string[] materialString = rfMaterial.TextID.Split('@');
-
-            string materialName = materialString[0].Split('|')[1];//<-- not safe
+            if (materialString.Length < 2)
+                materialName = rfMaterial.Description;
+            else
+                materialName = materialString[0].Split('|')[1];
 
             return materialName;
         }

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -66,6 +66,7 @@ namespace BH.Engine.RFEM
                 case "TypeID|CONCRETE":
                     return MaterialType.Concrete;
                 case "TypeID|TIMBER":
+                case "TypeID|CONIFEROUS":
                     return MaterialType.Timber;
                 case "TypeID|CABLE":
                     return MaterialType.Cable;

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -53,7 +53,7 @@ namespace BH.Engine.RFEM
 
             if(materialString.Count()<2)
             {
-                // raise warning
+                Engine.Reflection.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
                 return MaterialType.Steel;
             }
 
@@ -76,6 +76,7 @@ namespace BH.Engine.RFEM
                 case "TypeID|TENDON":
                     return MaterialType.Tendon;
                 default:
+                    Engine.Reflection.Compute.RecordWarning("Don't know how to make: " + materialString[1]);
                     return MaterialType.Undefined;
             }
 

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -61,12 +61,22 @@ namespace BH.Engine.RFEM
             {
                 case "TypeID|STEEL":
                     return MaterialType.Steel;
-                case "TypeID|Concrete"://best guess on string
+                case "TypeID|ALUMINIUM":
+                    return MaterialType.Aluminium;
+                case "TypeID|CONCRETE":
                     return MaterialType.Concrete;
-                case "TypeID|Timber"://best guess on string
+                case "TypeID|TIMBER":
                     return MaterialType.Timber;
+                case "TypeID|CABLE":
+                    return MaterialType.Cable;
+                case "TypeID|GLASS":
+                    return MaterialType.Glass;
+                case "TypeID|REBAR":
+                    return MaterialType.Rebar;
+                case "TypeID|TENDON":
+                    return MaterialType.Tendon;
                 default:
-                    return MaterialType.Steel;
+                    return MaterialType.Undefined;
             }
 
         }

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -42,6 +42,68 @@ namespace BH.Engine.RFEM
 
         public static IProfile GetSectionProfile(string profileName)
         {
+            string[] profileNameArr = profileName.Split(' ');
+            string[] profileValues;
+
+            switch (GetProfileType(profileName))
+            {
+                case ShapeType.Rectangle:
+                    profileValues = profileNameArr[1].Split('/');
+                    double b = Convert.ToDouble(profileValues[0]);
+                    double h = Convert.ToDouble(profileValues[1]);
+                    RectangleProfile profile = Structure.Create.RectangleProfile(h, b, 0);
+                    return profile;
+                case ShapeType.Box:
+                    profileValues = profileNameArr[1].Split('/');
+                    double b = Convert.ToDouble(profileValues[0]);
+                    double h = Convert.ToDouble(profileValues[1]);
+                    double t = Convert.ToDouble(profileValues[1]);
+                    BoxProfile profile = Structure.Create.BoxProfile(h, b, t, 0, 0);
+                    return profile;
+                case ShapeType.Angle:
+                    AngleProfile profile = new AngleProfile();
+                    break;
+                case ShapeType.ISection:
+                    ISectionProfile profile = new ISectionProfile();
+                    break;
+                case ShapeType.Tee:
+                    TSectionProfile profile = new TSectionProfile();
+                    break;
+                case ShapeType.Channel:
+                    ChannelProfile profile = new ChannelProfile();
+                    break;
+                case ShapeType.Tube:
+                    TubeProfile profile = new TubeProfile();
+                    break;
+                case ShapeType.Circle:
+                    CircleProfile profile = new CircleProfile();
+                    break;
+                case ShapeType.Zed:
+                    ZSectionProfile profile = new ZSectionProfile();
+                    break;
+                case ShapeType.FreeForm:
+                    FreeFormProfile profile = new FreeFormProfile();
+                    break;
+                case ShapeType.DoubleAngle:
+                    break;
+                case ShapeType.DoubleISection:
+                    break;
+                case ShapeType.DoubleChannel:
+                    break;
+                case ShapeType.Cable:
+                    break;
+                default:
+                    break;
+            }
+
+            /* ---TODO: cannot find shape types for these profiles: 
+                BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
+                BH.oM.Geometry.ShapeProfiles.FabricatedISectionProfile
+                BH.oM.Geometry.ShapeProfiles.GeneralisedFabricatedBoxProfile
+                BH.oM.Geometry.ShapeProfiles.GeneralisedTSectionProfile
+                BH.oM.Geometry.ShapeProfiles.KiteProfile
+                BH.oM.Geometry.ShapeProfiles.TaperedProfile
+                */
 
         }
 

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -48,6 +48,7 @@ namespace BH.Engine.RFEM
             string[] profileNameArr = profileName.Split(' ');
             string[] profileValues;
             double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
+            IProfile profile = null;
 
             if (profileNameArr.Length > 1)
             {
@@ -74,100 +75,160 @@ namespace BH.Engine.RFEM
                     case "UB":
                     case "UBP":
                     case "UC":
-                        double h = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
-                        double w = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
-                        double wt = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
-                        double ft = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
-                        double fr = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
-                        double tr = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        ISectionProfile profile_I = Structure.Create.ISectionProfile(h, w, wt, ft, fr, tr);
-                        return profile_I;
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        profile = Structure.Create.ISectionProfile(v1,v2,v3,v4,v5,v6);
+                        break;
+                    case "SHS":
+                    case "RHS":
+                    case "QRO":
+                    case "RRO":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        profile = Structure.Create.BoxProfile(v1, v2, v3, v4, v5);
+                        break;
+                    case "SQ-S":
+                    case "SQ-R":
+                    case "4KT":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        profile = Structure.Create.RectangleProfile(v1, v2, v3);
+                        break;
+
+                    case "L":
+                    case "UKA":
+                    case "LS":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, v5, v6);
+                        break;
+                    case "T":
+                    case "TB":
+                    case "TPS":
+                    case "TS":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        profile = Structure.Create.TSectionProfile(v1, v2, v3, v4, v5, v6);
+                        break;
+                    case "U":
+                    case "C":
+                    case "UPE":
+                    case "UAP":
+                    case "CH":
+                    case "UPN":
+                    case "PFC":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, v5, v6);
+                        break;
+                    case "CHS":
+                    case "RO":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue * 2;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
+                        profile = Structure.Create.TubeProfile(v1, v2);
+                        break;
+                    case "RD":
+                    case "ROD":
+                    case "RB":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue * 2;
+                        profile = Structure.Create.CircleProfile(v1);
+                        break;
+                    //case "Z":
+                    //case "KZ":
+                    //    v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                    //    v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                    //    v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                    //    v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                    //    v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                    //    v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                    //    profile = new ZSectionProfile(v1, v2, v3, v4, v5, v6, "< looks like the only way to create this now is to use the profile curves !! >");
+                    //    break;
                     default:
+                        Engine.Reflection.Compute.RecordError("Don't know how to make" + profileName);
                         break;
                 }
             }
 
-
-            switch (profileNameArr[0])
-            {
-                case "Rectangle":
-                case "T-Rectangle"://timber
-                    v1 = Convert.ToDouble(profileValues[0]);
-                    v2 = Convert.ToDouble(profileValues[1]);
-                    
-                    RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
-                    return profile;
-                case "SHS":
-                case "RHS":
-                case "QRO":
-                case "RRO":
-                case "TO":
-                case "HSH":
-                case "HSV":
-                    v1 = Convert.ToDouble(profileValues[0]);
-                    v2 = Convert.ToDouble(profileValues[1]);
-                    v3 = Convert.ToDouble(profileValues[2]);
-                    BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
-                    return profile;
-                case "L":
-                case "LU":
-                case "KLU":
-                case "LS":
-                    AngleProfile profile = new AngleProfile();
-                    break;
-                case "IS":
-                case "ITS":
-                case "IUH":
-                case "IUV":
-                    ISectionProfile profile = new ISectionProfile();
-                    break;
-                case "T":
-                case "TB":
-                case "TPS":
-                case "TS":
-                case "FB":
-                case "TH":
-                case "TV":
-                    TSectionProfile profile = new TSectionProfile();
-                    break;
-                case "U":
-                case "UPE":
-                case "UAP":
-                case "CH":
-                case "UPN":
-                case "PFC":
-                case "C":
-                case "UU":
-                case "UM":
-                case "PIH":
-                case "PIV":
-                    ChannelProfile profile = new ChannelProfile();
-                    break;
-                case "CHS":
-                case "RO":
-                case "Pipe":
-                case "Ring":
-                    TubeProfile profile = new TubeProfile();
-                    break;
-                case "RD":
-                case "ROD":
-                case "RB":
-                case "Round":
-                case "Circle":
-                case "T-Circle":
-                    CircleProfile profile = new CircleProfile();
-                    break;
-                case "Z":
-                case "KZ":
-                case "Z(A)":
-                case "Z(B)":
-                case "Z_AM":
-                case "Z_BM":
-                    ZSectionProfile profile = new ZSectionProfile();
-                    break;
-                default:
-                    break;
-            }
+            // for parametric section profiles
+            //switch (profileNameArr[0])
+            //{
+            //    case "Rectangle":
+            //    case "T-Rectangle"://timber
+            //        v1 = Convert.ToDouble(profileValues[0]);
+            //        v2 = Convert.ToDouble(profileValues[1]);
+            //        profile = Structure.Create.RectangleProfile(v1, v2, 0);
+            //        break;
+            //    case "TO":
+            //    case "HSH":
+            //    case "HSV":
+            //        v1 = Convert.ToDouble(profileValues[0]);
+            //        v2 = Convert.ToDouble(profileValues[1]);
+            //        v3 = Convert.ToDouble(profileValues[2]);
+            //        profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
+            //        break;
+            //    case "L":
+            //    case "LU":
+            //    case "KLU":
+            //    case "LS":
+            //        profile = new AngleProfile();
+            //        break;
+            //    case "IS":
+            //    case "ITS":
+            //    case "IUH":
+            //    case "IUV":
+            //        profile = new ISectionProfile();
+            //        break;
+            //    case "TS":
+            //    case "FB":
+            //    case "TH":
+            //    case "TV":
+            //        profile = new TSectionProfile();
+            //        break;
+            //    case "C":
+            //    case "UU":
+            //    case "UM":
+            //    case "PIH":
+            //    case "PIV":
+            //        profile = new ChannelProfile();
+            //        break;
+            //    case "Pipe":
+            //    case "Ring":
+            //        profile = new TubeProfile();
+            //        break;
+            //    case "Round":
+            //    case "Circle":
+            //    case "T-Circle":
+            //        profile = new CircleProfile();
+            //        break;
+            //    case "Z(A)":
+            //    case "Z(B)":
+            //    case "Z_AM":
+            //    case "Z_BM":
+            //        profile = new ZSectionProfile();
+            //        break;
+            //    default:
+            //        break;
+            //}
 
             /* ---TODO: cannot find shape types for these profiles: 
                 BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
@@ -178,6 +239,7 @@ namespace BH.Engine.RFEM
                 BH.oM.Geometry.ShapeProfiles.TaperedProfile
                 */
 
+            return profile;
         }
 
 

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.RFEM
 
             if (profileNameArr.Length > 1)
             {
-                //this is the case for Solid Timber 50/30
+                //this is the case for 'Solid Timber 50/30'
                 profileValues = profileNameArr[2].Split('/');//parametric sections
             }
             else
@@ -61,6 +61,10 @@ namespace BH.Engine.RFEM
                     profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
             }
 
+            for (int i = 0; i < 10; i++)
+            {
+
+            }
 
 
             switch (profileNameArr[0])

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -50,18 +50,18 @@ namespace BH.Engine.RFEM
             double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
             IProfile profile = null;
 
-            if (profileNameArr.Length > 2)
-            {
-                //this is the case for 'Solid Timber 50/30'
-                profileValues = profileNameArr[2].Split('/');//parametric sections
-            }
-            else
-            {
-                if (profileNameArr[0].Contains('/'))
-                    profileValues = profileNameArr[1].Split('/');//parametric sections
-                else
-                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
-            }
+            //if (profileNameArr.Length > 2)
+            //{
+            //    //this is the case for 'Solid Timber 50/30'
+            //    profileValues = profileNameArr[2].Split('/');//parametric sections
+            //}
+            //else
+            //{
+            //    if (profileNameArr[0].Contains('/'))
+            //        profileValues = profileNameArr[1].Split('/');//parametric sections
+            //    else
+            //        profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+            //}
 
             if (sectionDBProps != null)//section from RFEM Library
             {
@@ -83,6 +83,18 @@ namespace BH.Engine.RFEM
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
                         profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
                         break;
+                    case "IS"://parametric
+                    case "ITS":
+                    case "IUH":
+                    case "IUV":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
+                        v4 = sectionDBProps[3].fValue;
+                        v5 = sectionDBProps[4].fValue;
+                        v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
+                        break;
                     case "SHS":
                     case "RHS":
                     case "QRO":
@@ -94,12 +106,30 @@ namespace BH.Engine.RFEM
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
                         profile = Structure.Create.BoxProfile(v1, v2, v3, v4, v5);
                         break;
+                    case "TO"://parametric
+                    case "HSH":
+                    case "HSV":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
+                        v4 = sectionDBProps[3].fValue;
+                        v5 = sectionDBProps[4].fValue;
+                        profile = Structure.Create.BoxProfile(v1, v2, v3, v4, v5);
+                        break;
+
                     case "SQ-S":
                     case "SQ-R":
                     case "4KT":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        profile = Structure.Create.RectangleProfile(v1, v2, v3);
+                        break;
+                    case "Rectangle"://parametric
+                    case "T-Rectangle":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
                         profile = Structure.Create.RectangleProfile(v1, v2, v3);
                         break;
 
@@ -118,10 +148,20 @@ namespace BH.Engine.RFEM
                             v4 = v3;
                         profile = Structure.Create.AngleProfile(v1, v2, v3, v4, v5, v6);
                         break;
+                    case "LU"://parametric
+                    case "KLU":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
+                        v4 = sectionDBProps[3].fValue;
+                        v5 = sectionDBProps[4].fValue;
+                        v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, v5, v6);
+                        break;
+
                     case "T":
                     case "TB":
                     case "TPS":
-                    case "TS":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
@@ -130,6 +170,19 @@ namespace BH.Engine.RFEM
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
                         profile = Structure.Create.TSectionProfile(v1, v2, v3, v4, v5, v6);
                         break;
+                    case "TS"://parametric
+                    case "FB":
+                    case "TH":
+                    case "TV":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
+                        v4 = sectionDBProps[3].fValue;
+                        v5 = sectionDBProps[4].fValue;
+                        v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.TSectionProfile(v1, v2, v3, v4, v5, v6);
+                        break;
+
                     case "U":
                     case "C":
                     case "UPE":
@@ -145,10 +198,28 @@ namespace BH.Engine.RFEM
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
                         profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, v5, v6);
                         break;
+                    case "UU"://parametric
+                    case "UM":
+                    case "PIH":
+                    case "PIV":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
+                        v3 = sectionDBProps[2].fValue;
+                        v4 = sectionDBProps[3].fValue;
+                        v5 = sectionDBProps[4].fValue;
+                        v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, v5, v6);
+                        break;
                     case "CHS":
                     case "RO":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_D).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
+                        profile = Structure.Create.TubeProfile(v1, v2);
+                        break;
+                    case "Pipe"://parametric
+                    case "Ring":
+                        v1 = sectionDBProps[0].fValue;
+                        v2 = sectionDBProps[1].fValue;
                         profile = Structure.Create.TubeProfile(v1, v2);
                         break;
                     case "RD":
@@ -157,6 +228,13 @@ namespace BH.Engine.RFEM
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_D).fValue;
                         profile = Structure.Create.CircleProfile(v1);
                         break;
+                    case "Round"://parametric 
+                    case "Circle":
+                    case "T-Circle":
+                        v1 = sectionDBProps[0].fValue;
+                        profile = Structure.Create.CircleProfile(v1);
+                        break;
+
                     //case "Z":
                     //case "KZ":
                     //    v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
@@ -169,83 +247,6 @@ namespace BH.Engine.RFEM
                     //    break;
                     default:
                         Engine.Reflection.Compute.RecordError("Don't know how to make" + profileName);
-                        break;
-                }
-            }
-            else
-            {
-                //for parametric section profiles
-                switch (profileNameArr[0])
-                {
-                    case "Rectangle":
-                    case "T-Rectangle"://timber
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        profile = Structure.Create.RectangleProfile(v1, v2, 0);
-                        break;
-                    case "TO":
-                    case "HSH":
-                    case "HSV":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        v3 = Convert.ToDouble(profileValues[2]);
-                        profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
-                        break;
-                    case "L":
-                    case "LU":
-                    case "KLU":
-                    case "LS":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        v3 = Convert.ToDouble(profileValues[2]);
-                        v4 = Convert.ToDouble(profileValues[4]);
-                        v5 = Convert.ToDouble(profileValues[5]);
-                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, 0, 0);
-                        break;
-                    case "IS":
-                    case "ITS":
-                    case "IUH":
-                    case "IUV":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        v3 = Convert.ToDouble(profileValues[2]);
-                        v4 = Convert.ToDouble(profileValues[4]);
-                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, 0, 0);
-                        break;
-                    case "TS":
-                    case "FB":
-                    case "TH":
-                    case "TV":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        v3 = Convert.ToDouble(profileValues[2]);
-                        v4 = Convert.ToDouble(profileValues[4]);
-                        profile = Structure.Create.TSectionProfile(v1, v2, v4, v3, 0, 0);
-                        break;
-                    case "C":
-                    case "UU":
-                    case "UM":
-                    case "PIH":
-                    case "PIV":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        v3 = Convert.ToDouble(profileValues[2]);
-                        v4 = Convert.ToDouble(profileValues[4]);
-                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, 0, 0);
-                        break;
-                    case "Pipe":
-                    case "Ring":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        v2 = Convert.ToDouble(profileValues[1]);
-                        profile = Structure.Create.TubeProfile(v1, v2);
-                        break;
-                    case "Round":
-                    case "Circle":
-                    case "T-Circle":
-                        v1 = Convert.ToDouble(profileValues[0]);
-                        profile = Structure.Create.CircleProfile(v1);
-                        break;
-                    default:
                         break;
                 }
             }

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -48,7 +48,6 @@ namespace BH.Engine.RFEM
             string[] profileNameArr = profileName.Split(' ');
             string[] profileValues;
             double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
-            IProfile profile;
 
             if (profileNameArr.Length > 1)
             {
@@ -63,9 +62,29 @@ namespace BH.Engine.RFEM
                     profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
             }
 
-            for (int i = 0; i < 10; i++)
+            if(sectionDBProps != null)//section from RFEM Library
             {
-
+                switch (profileNameArr[0])
+                {
+                    case "I":
+                    case "IPE":
+                    case "HE":
+                    case "HEA":
+                    case "HEB":
+                    case "UB":
+                    case "UBP":
+                    case "UC":
+                        double h = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        double w = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
+                        double wt = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        double ft = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
+                        double fr = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
+                        double tr = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        ISectionProfile profile_I = Structure.Create.ISectionProfile(h, w, wt, ft, fr, tr);
+                        return profile_I;
+                    default:
+                        break;
+                }
             }
 
 
@@ -76,7 +95,7 @@ namespace BH.Engine.RFEM
                     v1 = Convert.ToDouble(profileValues[0]);
                     v2 = Convert.ToDouble(profileValues[1]);
                     
-                    profile = Structure.Create.RectangleProfile(v1, v2, 0);
+                    RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
                     return profile;
                 case "SHS":
                 case "RHS":
@@ -96,14 +115,6 @@ namespace BH.Engine.RFEM
                 case "LS":
                     AngleProfile profile = new AngleProfile();
                     break;
-                case "I":
-                case "IPE":
-                case "HE":
-                case "HEA":
-                case "HEB":
-                case "UB":
-                case "UBP":
-                case "UC":
                 case "IS":
                 case "ITS":
                 case "IUH":

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -50,20 +50,20 @@ namespace BH.Engine.RFEM
             double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
             IProfile profile = null;
 
-            //if (profileNameArr.Length > 2)
-            //{
-            //    //this is the case for 'Solid Timber 50/30'
-            //    profileValues = profileNameArr[2].Split('/');//parametric sections
-            //}
-            //else
-            //{
-            //    if (profileNameArr[0].Contains('x'))
-            //        profileValues = profileNameArr[1].Split('/');//parametric sections
-            //    else
-            //        profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
-            //}
+            if (profileNameArr.Length > 2)
+            {
+                //this is the case for 'Solid Timber 50/30'
+                profileValues = profileNameArr[2].Split('/');//parametric sections
+            }
+            else
+            {
+                if (profileNameArr[0].Contains('/'))
+                    profileValues = profileNameArr[1].Split('/');//parametric sections
+                else
+                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+            }
 
-            if(sectionDBProps != null)//section from RFEM Library
+            if (sectionDBProps != null)//section from RFEM Library
             {
                 switch (profileNameArr[0])
                 {
@@ -81,7 +81,7 @@ namespace BH.Engine.RFEM
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Structure.Create.ISectionProfile(v1,v2,v3,v4,v5,v6);
+                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
                         break;
                     case "SHS":
                     case "RHS":
@@ -172,67 +172,83 @@ namespace BH.Engine.RFEM
                         break;
                 }
             }
-
-            // for parametric section profiles
-            //switch (profileNameArr[0])
-            //{
-            //    case "Rectangle":
-            //    case "T-Rectangle"://timber
-            //        v1 = Convert.ToDouble(profileValues[0]);
-            //        v2 = Convert.ToDouble(profileValues[1]);
-            //        profile = Structure.Create.RectangleProfile(v1, v2, 0);
-            //        break;
-            //    case "TO":
-            //    case "HSH":
-            //    case "HSV":
-            //        v1 = Convert.ToDouble(profileValues[0]);
-            //        v2 = Convert.ToDouble(profileValues[1]);
-            //        v3 = Convert.ToDouble(profileValues[2]);
-            //        profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
-            //        break;
-            //    case "L":
-            //    case "LU":
-            //    case "KLU":
-            //    case "LS":
-            //        profile = new AngleProfile();
-            //        break;
-            //    case "IS":
-            //    case "ITS":
-            //    case "IUH":
-            //    case "IUV":
-            //        profile = new ISectionProfile();
-            //        break;
-            //    case "TS":
-            //    case "FB":
-            //    case "TH":
-            //    case "TV":
-            //        profile = new TSectionProfile();
-            //        break;
-            //    case "C":
-            //    case "UU":
-            //    case "UM":
-            //    case "PIH":
-            //    case "PIV":
-            //        profile = new ChannelProfile();
-            //        break;
-            //    case "Pipe":
-            //    case "Ring":
-            //        profile = new TubeProfile();
-            //        break;
-            //    case "Round":
-            //    case "Circle":
-            //    case "T-Circle":
-            //        profile = new CircleProfile();
-            //        break;
-            //    case "Z(A)":
-            //    case "Z(B)":
-            //    case "Z_AM":
-            //    case "Z_BM":
-            //        profile = new ZSectionProfile();
-            //        break;
-            //    default:
-            //        break;
-            //}
+            else
+            {
+                //for parametric section profiles
+                switch (profileNameArr[0])
+                {
+                    case "Rectangle":
+                    case "T-Rectangle"://timber
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        profile = Structure.Create.RectangleProfile(v1, v2, 0);
+                        break;
+                    case "TO":
+                    case "HSH":
+                    case "HSV":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        v3 = Convert.ToDouble(profileValues[2]);
+                        profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
+                        break;
+                    case "L":
+                    case "LU":
+                    case "KLU":
+                    case "LS":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        v3 = Convert.ToDouble(profileValues[2]);
+                        v4 = Convert.ToDouble(profileValues[4]);
+                        v5 = Convert.ToDouble(profileValues[5]);
+                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, 0, 0);
+                        break;
+                    case "IS":
+                    case "ITS":
+                    case "IUH":
+                    case "IUV":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        v3 = Convert.ToDouble(profileValues[2]);
+                        v4 = Convert.ToDouble(profileValues[4]);
+                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, 0, 0);
+                        break;
+                    case "TS":
+                    case "FB":
+                    case "TH":
+                    case "TV":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        v3 = Convert.ToDouble(profileValues[2]);
+                        v4 = Convert.ToDouble(profileValues[4]);
+                        profile = Structure.Create.TSectionProfile(v1, v2, v4, v3, 0, 0);
+                        break;
+                    case "C":
+                    case "UU":
+                    case "UM":
+                    case "PIH":
+                    case "PIV":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        v3 = Convert.ToDouble(profileValues[2]);
+                        v4 = Convert.ToDouble(profileValues[4]);
+                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, 0, 0);
+                        break;
+                    case "Pipe":
+                    case "Ring":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        v2 = Convert.ToDouble(profileValues[1]);
+                        profile = Structure.Create.TubeProfile(v1, v2);
+                        break;
+                    case "Round":
+                    case "Circle":
+                    case "T-Circle":
+                        v1 = Convert.ToDouble(profileValues[0]);
+                        profile = Structure.Create.CircleProfile(v1);
+                        break;
+                    default:
+                        break;
+                }
+            }
 
             /* ---TODO: cannot find shape types for these profiles: 
                 BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -42,43 +42,109 @@ namespace BH.Engine.RFEM
 
         public static IProfile GetSectionProfile(string profileName)
         {
+            // standard section name: SHS 25x25x2
+            // parametric section name: TO 30/30/5/5/5/5
             string[] profileNameArr = profileName.Split(' ');
             string[] profileValues;
+            double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
 
-            switch (GetProfileType(profileName))
+            if (profileNameArr.Length > 1)
             {
-                case ShapeType.Rectangle:
-                    profileValues = profileNameArr[1].Split('/');
-                    double b = Convert.ToDouble(profileValues[0]);
-                    double h = Convert.ToDouble(profileValues[1]);
-                    RectangleProfile profile = Structure.Create.RectangleProfile(h, b, 0);
+                //this is the case for Solid Timber 50/30
+                profileValues = profileNameArr[2].Split('/');//parametric sections
+            }
+            else
+            {
+                if(profileNameArr[0].Contains('x'))
+                    profileValues = profileNameArr[1].Split('/');//parametric sections
+                else
+                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+            }
+
+
+
+            switch (profileNameArr[0])
+            {
+                case "Rectangle":
+                case "T-Rectangle"://timber
+                    v1 = Convert.ToDouble(profileValues[0]);
+                    v2 = Convert.ToDouble(profileValues[1]);
+                    RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
                     return profile;
-                case ShapeType.Box:
-                    profileValues = profileNameArr[1].Split('/');
-                    double b = Convert.ToDouble(profileValues[0]);
-                    double h = Convert.ToDouble(profileValues[1]);
-                    double t = Convert.ToDouble(profileValues[1]);
-                    BoxProfile profile = Structure.Create.BoxProfile(h, b, t, 0, 0);
+                case "SHS":
+                case "RHS":
+                case "QRO":
+                case "RRO":
+                case "TO":
+                case "HSH":
+                case "HSV":
+                    v1 = Convert.ToDouble(profileValues[0]);
+                    v2 = Convert.ToDouble(profileValues[1]);
+                    v3 = Convert.ToDouble(profileValues[2]);
+                    BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
                     return profile;
-                case ShapeType.Angle:
+                case "L":
+                case "LU":
+                case "KLU":
+                case "LS":
                     AngleProfile profile = new AngleProfile();
                     break;
-                case ShapeType.ISection:
+                case "I":
+                case "IPE":
+                case "HE":
+                case "HEA":
+                case "HEB":
+                case "UB":
+                case "UBP":
+                case "UC":
+                case "IS":
+                case "ITS":
+                case "IUH":
+                case "IUV":
                     ISectionProfile profile = new ISectionProfile();
                     break;
-                case ShapeType.Tee:
+                case "T":
+                case "TB":
+                case "TPS":
+                case "TS":
+                case "FB":
+                case "TH":
+                case "TV":
                     TSectionProfile profile = new TSectionProfile();
                     break;
-                case ShapeType.Channel:
+                case "U":
+                case "UPE":
+                case "UAP":
+                case "CH":
+                case "UPN":
+                case "PFC":
+                case "C":
+                case "UU":
+                case "UM":
+                case "PIH":
+                case "PIV":
                     ChannelProfile profile = new ChannelProfile();
                     break;
-                case ShapeType.Tube:
+                case "CHS":
+                case "RO":
+                case "Pipe":
+                case "Ring":
                     TubeProfile profile = new TubeProfile();
                     break;
-                case ShapeType.Circle:
+                case "RD":
+                case "ROD":
+                case "RB":
+                case "Round":
+                case "Circle":
+                case "T-Circle":
                     CircleProfile profile = new CircleProfile();
                     break;
-                case ShapeType.Zed:
+                case "Z":
+                case "KZ":
+                case "Z(A)":
+                case "Z(B)":
+                case "Z_AM":
+                case "Z_BM":
                     ZSectionProfile profile = new ZSectionProfile();
                     break;
                 case ShapeType.FreeForm:

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -147,17 +147,6 @@ namespace BH.Engine.RFEM
                 case "Z_BM":
                     ZSectionProfile profile = new ZSectionProfile();
                     break;
-                case ShapeType.FreeForm:
-                    FreeFormProfile profile = new FreeFormProfile();
-                    break;
-                case ShapeType.DoubleAngle:
-                    break;
-                case ShapeType.DoubleISection:
-                    break;
-                case ShapeType.DoubleChannel:
-                    break;
-                case ShapeType.Cable:
-                    break;
                 default:
                     break;
             }
@@ -173,55 +162,6 @@ namespace BH.Engine.RFEM
 
         }
 
-        public static ShapeType GetProfileType(string profileName)
-        {
-            string typeString = profileName.Split(' ')[0];
-            
-            ShapeType profileType;
-
-            switch (typeString)
-            {
-                case "RHS":
-                    profileType = ShapeType.Rectangle;
-                    break;
-                case "SHS":
-                    profileType = ShapeType.Box;
-                    break;
-                case "IPE":
-                    profileType = ShapeType.ISection;
-                    break;
-                case "T":
-                    profileType = ShapeType.Tee;
-                    break;
-                case "UPE":
-                    profileType = ShapeType.Channel;
-                    break;
-                case "CHS":
-                    profileType = ShapeType.Tube;
-                    break;
-                case "L":
-                    profileType = ShapeType.Angle;
-                    break;
-                case "RD":
-                    profileType = ShapeType.Circle;
-                    break;
-                case "Z":
-                    profileType = ShapeType.Zed;
-                    break;
-                //case ShapeType.FreeForm:
-                //case ShapeType.DoubleAngle:
-                //case ShapeType.DoubleISection:
-                //case ShapeType.DoubleChannel:
-                //case ShapeType.Cable:
-
-                default:
-                    profileType = ShapeType.ISection;
-                    Engine.Reflection.Compute.RecordError("Don't know how to make" + profileName);
-                    break;
-            }
-
-            return profileType;
-        }
 
         /***************************************************/
     }

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.RFEM
             //        profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
             //}
 
-            if (sectionDBProps != null)//section from RFEM Library
+            if (sectionDBProps != null)//section from RFEM Library including sections defined in RFEM model
             {
                 switch (profileNameArr[0])
                 {

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -244,7 +244,7 @@ namespace BH.Engine.RFEM
                     //    profile = new ZSectionProfile(v1, v2, v3, v4, v5, v6, "< looks like the only way to create this now is to use the profile curves !! >");
                     //    break;
                     default:
-                        Engine.Reflection.Compute.RecordError("Don't know how to make" + profileName);
+                        Engine.Reflection.Compute.RecordError("Don't know how to make profile " + profileName);
                         break;
                 }
             }

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -31,6 +31,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
+using rf3 = Dlubal.RFEM3;
 
 namespace BH.Engine.RFEM
 {
@@ -40,131 +41,133 @@ namespace BH.Engine.RFEM
         /**** Public Methods                            ****/
         /***************************************************/
 
-        //public static IProfile GetSectionProfile(string profileName)
-        //{
-        //    // standard section name: SHS 25x25x2
-        //    // parametric section name: TO 30/30/5/5/5/5
-        //    string[] profileNameArr = profileName.Split(' ');
-        //    string[] profileValues;
-        //    double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
+        public static IProfile GetSectionProfile(string profileName, rf3.DB_CRSC_PROPERTY[] sectionDBProps = null)
+        {
+            // standard section name: SHS 25x25x2
+            // parametric section name: TO 30/30/5/5/5/5
+            string[] profileNameArr = profileName.Split(' ');
+            string[] profileValues;
+            double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
+            IProfile profile;
 
-        //    if (profileNameArr.Length > 1)
-        //    {
-        //        //this is the case for 'Solid Timber 50/30'
-        //        profileValues = profileNameArr[2].Split('/');//parametric sections
-        //    }
-        //    else
-        //    {
-        //        if(profileNameArr[0].Contains('x'))
-        //            profileValues = profileNameArr[1].Split('/');//parametric sections
-        //        else
-        //            profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
-        //    }
+            if (profileNameArr.Length > 1)
+            {
+                //this is the case for 'Solid Timber 50/30'
+                profileValues = profileNameArr[2].Split('/');//parametric sections
+            }
+            else
+            {
+                if (profileNameArr[0].Contains('x'))
+                    profileValues = profileNameArr[1].Split('/');//parametric sections
+                else
+                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+            }
 
-        //    for (int i = 0; i < 10; i++)
-        //    {
+            for (int i = 0; i < 10; i++)
+            {
 
-        //    }
+            }
 
 
-        //    switch (profileNameArr[0])
-        //    {
-        //        case "Rectangle":
-        //        case "T-Rectangle"://timber
-        //            v1 = Convert.ToDouble(profileValues[0]);
-        //            v2 = Convert.ToDouble(profileValues[1]);
-        //            RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
-        //            return profile;
-        //        case "SHS":
-        //        case "RHS":
-        //        case "QRO":
-        //        case "RRO":
-        //        case "TO":
-        //        case "HSH":
-        //        case "HSV":
-        //            v1 = Convert.ToDouble(profileValues[0]);
-        //            v2 = Convert.ToDouble(profileValues[1]);
-        //            v3 = Convert.ToDouble(profileValues[2]);
-        //            BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
-        //            return profile;
-        //        case "L":
-        //        case "LU":
-        //        case "KLU":
-        //        case "LS":
-        //            AngleProfile profile = new AngleProfile();
-        //            break;
-        //        case "I":
-        //        case "IPE":
-        //        case "HE":
-        //        case "HEA":
-        //        case "HEB":
-        //        case "UB":
-        //        case "UBP":
-        //        case "UC":
-        //        case "IS":
-        //        case "ITS":
-        //        case "IUH":
-        //        case "IUV":
-        //            ISectionProfile profile = new ISectionProfile();
-        //            break;
-        //        case "T":
-        //        case "TB":
-        //        case "TPS":
-        //        case "TS":
-        //        case "FB":
-        //        case "TH":
-        //        case "TV":
-        //            TSectionProfile profile = new TSectionProfile();
-        //            break;
-        //        case "U":
-        //        case "UPE":
-        //        case "UAP":
-        //        case "CH":
-        //        case "UPN":
-        //        case "PFC":
-        //        case "C":
-        //        case "UU":
-        //        case "UM":
-        //        case "PIH":
-        //        case "PIV":
-        //            ChannelProfile profile = new ChannelProfile();
-        //            break;
-        //        case "CHS":
-        //        case "RO":
-        //        case "Pipe":
-        //        case "Ring":
-        //            TubeProfile profile = new TubeProfile();
-        //            break;
-        //        case "RD":
-        //        case "ROD":
-        //        case "RB":
-        //        case "Round":
-        //        case "Circle":
-        //        case "T-Circle":
-        //            CircleProfile profile = new CircleProfile();
-        //            break;
-        //        case "Z":
-        //        case "KZ":
-        //        case "Z(A)":
-        //        case "Z(B)":
-        //        case "Z_AM":
-        //        case "Z_BM":
-        //            ZSectionProfile profile = new ZSectionProfile();
-        //            break;
-        //        default:
-        //            break;
-        //    }
+            switch (profileNameArr[0])
+            {
+                case "Rectangle":
+                case "T-Rectangle"://timber
+                    v1 = Convert.ToDouble(profileValues[0]);
+                    v2 = Convert.ToDouble(profileValues[1]);
+                    
+                    profile = Structure.Create.RectangleProfile(v1, v2, 0);
+                    return profile;
+                case "SHS":
+                case "RHS":
+                case "QRO":
+                case "RRO":
+                case "TO":
+                case "HSH":
+                case "HSV":
+                    v1 = Convert.ToDouble(profileValues[0]);
+                    v2 = Convert.ToDouble(profileValues[1]);
+                    v3 = Convert.ToDouble(profileValues[2]);
+                    BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
+                    return profile;
+                case "L":
+                case "LU":
+                case "KLU":
+                case "LS":
+                    AngleProfile profile = new AngleProfile();
+                    break;
+                case "I":
+                case "IPE":
+                case "HE":
+                case "HEA":
+                case "HEB":
+                case "UB":
+                case "UBP":
+                case "UC":
+                case "IS":
+                case "ITS":
+                case "IUH":
+                case "IUV":
+                    ISectionProfile profile = new ISectionProfile();
+                    break;
+                case "T":
+                case "TB":
+                case "TPS":
+                case "TS":
+                case "FB":
+                case "TH":
+                case "TV":
+                    TSectionProfile profile = new TSectionProfile();
+                    break;
+                case "U":
+                case "UPE":
+                case "UAP":
+                case "CH":
+                case "UPN":
+                case "PFC":
+                case "C":
+                case "UU":
+                case "UM":
+                case "PIH":
+                case "PIV":
+                    ChannelProfile profile = new ChannelProfile();
+                    break;
+                case "CHS":
+                case "RO":
+                case "Pipe":
+                case "Ring":
+                    TubeProfile profile = new TubeProfile();
+                    break;
+                case "RD":
+                case "ROD":
+                case "RB":
+                case "Round":
+                case "Circle":
+                case "T-Circle":
+                    CircleProfile profile = new CircleProfile();
+                    break;
+                case "Z":
+                case "KZ":
+                case "Z(A)":
+                case "Z(B)":
+                case "Z_AM":
+                case "Z_BM":
+                    ZSectionProfile profile = new ZSectionProfile();
+                    break;
+                default:
+                    break;
+            }
 
-        //    /* ---TODO: cannot find shape types for these profiles: 
-        //        BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
-        //        BH.oM.Geometry.ShapeProfiles.FabricatedISectionProfile
-        //        BH.oM.Geometry.ShapeProfiles.GeneralisedFabricatedBoxProfile
-        //        BH.oM.Geometry.ShapeProfiles.GeneralisedTSectionProfile
-        //        BH.oM.Geometry.ShapeProfiles.KiteProfile
-        //        BH.oM.Geometry.ShapeProfiles.TaperedProfile
-        //        */
+            /* ---TODO: cannot find shape types for these profiles: 
+                BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
+                BH.oM.Geometry.ShapeProfiles.FabricatedISectionProfile
+                BH.oM.Geometry.ShapeProfiles.GeneralisedFabricatedBoxProfile
+                BH.oM.Geometry.ShapeProfiles.GeneralisedTSectionProfile
+                BH.oM.Geometry.ShapeProfiles.KiteProfile
+                BH.oM.Geometry.ShapeProfiles.TaperedProfile
+                */
 
-        //}
+        }
 
 
         /***************************************************/

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -91,9 +91,9 @@ namespace BH.Engine.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        v5 = sectionDBProps[4].fValue;
-                        v6 = sectionDBProps[5].fValue;
-                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
+                        //v5 = sectionDBProps[4].fValue;
+                        //v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.ISectionProfile(v1, v2, v3, v4, 0, 0);
                         break;
                     case "SHS":
                     case "RHS":
@@ -102,9 +102,7 @@ namespace BH.Engine.RFEM
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
-                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
-                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Structure.Create.BoxProfile(v1, v2, v3, v4, v5);
+                        profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
                         break;
                     case "TO"://parametric
                     case "HSH":
@@ -113,8 +111,8 @@ namespace BH.Engine.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        v5 = sectionDBProps[4].fValue;
-                        profile = Structure.Create.BoxProfile(v1, v2, v3, v4, v5);
+                        //v5 = sectionDBProps[4].fValue;
+                        profile = Structure.Create.BoxProfile(v1, v2, v3, v4, 0);
                         break;
 
                     case "SQ-S":
@@ -154,9 +152,9 @@ namespace BH.Engine.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        v5 = sectionDBProps[4].fValue;
-                        v6 = sectionDBProps[5].fValue;
-                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, v5, v6);
+                        //v5 = sectionDBProps[4].fValue;
+                        //v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.AngleProfile(v1, v2, v3, v4, 0, 0);
                         break;
 
                     case "T":
@@ -178,9 +176,9 @@ namespace BH.Engine.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        v5 = sectionDBProps[4].fValue;
-                        v6 = sectionDBProps[5].fValue;
-                        profile = Structure.Create.TSectionProfile(v1, v2, v3, v4, v5, v6);
+                        //v5 = sectionDBProps[4].fValue;
+                        //v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.TSectionProfile(v1, v2, v3, v4, 0, 0);
                         break;
 
                     case "U":
@@ -206,9 +204,9 @@ namespace BH.Engine.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        v5 = sectionDBProps[4].fValue;
-                        v6 = sectionDBProps[5].fValue;
-                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, v5, v6);
+                        //v5 = sectionDBProps[4].fValue;
+                        //v6 = sectionDBProps[5].fValue;
+                        profile = Structure.Create.ChannelProfile(v1, v2, v3, v4, 0, 0);
                         break;
                     case "CHS":
                     case "RO":

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -40,11 +40,15 @@ namespace BH.Engine.RFEM
         /**** Public Methods                            ****/
         /***************************************************/
 
+        public static IProfile GetSectionProfile(string profileName)
+        {
+
+        }
 
         public static ShapeType GetProfileType(string profileName)
         {
             string typeString = profileName.Split(' ')[0];
-
+            
             ShapeType profileType;
 
             switch (typeString)
@@ -84,6 +88,7 @@ namespace BH.Engine.RFEM
 
                 default:
                     profileType = ShapeType.ISection;
+                    Engine.Reflection.Compute.RecordError("Don't know how to make" + profileName);
                     break;
             }
 

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -50,18 +50,18 @@ namespace BH.Engine.RFEM
             double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
             IProfile profile = null;
 
-            if (profileNameArr.Length > 1)
-            {
-                //this is the case for 'Solid Timber 50/30'
-                profileValues = profileNameArr[2].Split('/');//parametric sections
-            }
-            else
-            {
-                if (profileNameArr[0].Contains('x'))
-                    profileValues = profileNameArr[1].Split('/');//parametric sections
-                else
-                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
-            }
+            //if (profileNameArr.Length > 2)
+            //{
+            //    //this is the case for 'Solid Timber 50/30'
+            //    profileValues = profileNameArr[2].Split('/');//parametric sections
+            //}
+            //else
+            //{
+            //    if (profileNameArr[0].Contains('x'))
+            //        profileValues = profileNameArr[1].Split('/');//parametric sections
+            //    else
+            //        profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+            //}
 
             if(sectionDBProps != null)//section from RFEM Library
             {
@@ -97,7 +97,7 @@ namespace BH.Engine.RFEM
                     case "SQ-S":
                     case "SQ-R":
                     case "4KT":
-                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         profile = Structure.Create.RectangleProfile(v1, v2, v3);
@@ -108,10 +108,14 @@ namespace BH.Engine.RFEM
                     case "LS":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
-                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
+                        if (v1 == 0)
+                            v1 = v2;
+                        if (v4 == 0)
+                            v4 = v3;
                         profile = Structure.Create.AngleProfile(v1, v2, v3, v4, v5, v6);
                         break;
                     case "T":
@@ -143,14 +147,14 @@ namespace BH.Engine.RFEM
                         break;
                     case "CHS":
                     case "RO":
-                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue * 2;
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_D).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
                         profile = Structure.Create.TubeProfile(v1, v2);
                         break;
                     case "RD":
                     case "ROD":
                     case "RB":
-                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue * 2;
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_D).fValue;
                         profile = Structure.Create.CircleProfile(v1);
                         break;
                     //case "Z":

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -33,6 +33,7 @@ using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = Dlubal.RFEM3;
 
+
 namespace BH.Engine.RFEM
 {
     public static partial class Query

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -40,131 +40,131 @@ namespace BH.Engine.RFEM
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IProfile GetSectionProfile(string profileName)
-        {
-            // standard section name: SHS 25x25x2
-            // parametric section name: TO 30/30/5/5/5/5
-            string[] profileNameArr = profileName.Split(' ');
-            string[] profileValues;
-            double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
+        //public static IProfile GetSectionProfile(string profileName)
+        //{
+        //    // standard section name: SHS 25x25x2
+        //    // parametric section name: TO 30/30/5/5/5/5
+        //    string[] profileNameArr = profileName.Split(' ');
+        //    string[] profileValues;
+        //    double v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
 
-            if (profileNameArr.Length > 1)
-            {
-                //this is the case for 'Solid Timber 50/30'
-                profileValues = profileNameArr[2].Split('/');//parametric sections
-            }
-            else
-            {
-                if(profileNameArr[0].Contains('x'))
-                    profileValues = profileNameArr[1].Split('/');//parametric sections
-                else
-                    profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
-            }
+        //    if (profileNameArr.Length > 1)
+        //    {
+        //        //this is the case for 'Solid Timber 50/30'
+        //        profileValues = profileNameArr[2].Split('/');//parametric sections
+        //    }
+        //    else
+        //    {
+        //        if(profileNameArr[0].Contains('x'))
+        //            profileValues = profileNameArr[1].Split('/');//parametric sections
+        //        else
+        //            profileValues = profileNameArr[1].Split('x');//standard sections - Note: can have format "IPE 80" and "IPE 750x137"
+        //    }
 
-            for (int i = 0; i < 10; i++)
-            {
+        //    for (int i = 0; i < 10; i++)
+        //    {
 
-            }
+        //    }
 
 
-            switch (profileNameArr[0])
-            {
-                case "Rectangle":
-                case "T-Rectangle"://timber
-                    v1 = Convert.ToDouble(profileValues[0]);
-                    v2 = Convert.ToDouble(profileValues[1]);
-                    RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
-                    return profile;
-                case "SHS":
-                case "RHS":
-                case "QRO":
-                case "RRO":
-                case "TO":
-                case "HSH":
-                case "HSV":
-                    v1 = Convert.ToDouble(profileValues[0]);
-                    v2 = Convert.ToDouble(profileValues[1]);
-                    v3 = Convert.ToDouble(profileValues[2]);
-                    BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
-                    return profile;
-                case "L":
-                case "LU":
-                case "KLU":
-                case "LS":
-                    AngleProfile profile = new AngleProfile();
-                    break;
-                case "I":
-                case "IPE":
-                case "HE":
-                case "HEA":
-                case "HEB":
-                case "UB":
-                case "UBP":
-                case "UC":
-                case "IS":
-                case "ITS":
-                case "IUH":
-                case "IUV":
-                    ISectionProfile profile = new ISectionProfile();
-                    break;
-                case "T":
-                case "TB":
-                case "TPS":
-                case "TS":
-                case "FB":
-                case "TH":
-                case "TV":
-                    TSectionProfile profile = new TSectionProfile();
-                    break;
-                case "U":
-                case "UPE":
-                case "UAP":
-                case "CH":
-                case "UPN":
-                case "PFC":
-                case "C":
-                case "UU":
-                case "UM":
-                case "PIH":
-                case "PIV":
-                    ChannelProfile profile = new ChannelProfile();
-                    break;
-                case "CHS":
-                case "RO":
-                case "Pipe":
-                case "Ring":
-                    TubeProfile profile = new TubeProfile();
-                    break;
-                case "RD":
-                case "ROD":
-                case "RB":
-                case "Round":
-                case "Circle":
-                case "T-Circle":
-                    CircleProfile profile = new CircleProfile();
-                    break;
-                case "Z":
-                case "KZ":
-                case "Z(A)":
-                case "Z(B)":
-                case "Z_AM":
-                case "Z_BM":
-                    ZSectionProfile profile = new ZSectionProfile();
-                    break;
-                default:
-                    break;
-            }
+        //    switch (profileNameArr[0])
+        //    {
+        //        case "Rectangle":
+        //        case "T-Rectangle"://timber
+        //            v1 = Convert.ToDouble(profileValues[0]);
+        //            v2 = Convert.ToDouble(profileValues[1]);
+        //            RectangleProfile profile = Structure.Create.RectangleProfile(v1, v2, 0);
+        //            return profile;
+        //        case "SHS":
+        //        case "RHS":
+        //        case "QRO":
+        //        case "RRO":
+        //        case "TO":
+        //        case "HSH":
+        //        case "HSV":
+        //            v1 = Convert.ToDouble(profileValues[0]);
+        //            v2 = Convert.ToDouble(profileValues[1]);
+        //            v3 = Convert.ToDouble(profileValues[2]);
+        //            BoxProfile profile = Structure.Create.BoxProfile(v1, v2, v3, 0, 0);
+        //            return profile;
+        //        case "L":
+        //        case "LU":
+        //        case "KLU":
+        //        case "LS":
+        //            AngleProfile profile = new AngleProfile();
+        //            break;
+        //        case "I":
+        //        case "IPE":
+        //        case "HE":
+        //        case "HEA":
+        //        case "HEB":
+        //        case "UB":
+        //        case "UBP":
+        //        case "UC":
+        //        case "IS":
+        //        case "ITS":
+        //        case "IUH":
+        //        case "IUV":
+        //            ISectionProfile profile = new ISectionProfile();
+        //            break;
+        //        case "T":
+        //        case "TB":
+        //        case "TPS":
+        //        case "TS":
+        //        case "FB":
+        //        case "TH":
+        //        case "TV":
+        //            TSectionProfile profile = new TSectionProfile();
+        //            break;
+        //        case "U":
+        //        case "UPE":
+        //        case "UAP":
+        //        case "CH":
+        //        case "UPN":
+        //        case "PFC":
+        //        case "C":
+        //        case "UU":
+        //        case "UM":
+        //        case "PIH":
+        //        case "PIV":
+        //            ChannelProfile profile = new ChannelProfile();
+        //            break;
+        //        case "CHS":
+        //        case "RO":
+        //        case "Pipe":
+        //        case "Ring":
+        //            TubeProfile profile = new TubeProfile();
+        //            break;
+        //        case "RD":
+        //        case "ROD":
+        //        case "RB":
+        //        case "Round":
+        //        case "Circle":
+        //        case "T-Circle":
+        //            CircleProfile profile = new CircleProfile();
+        //            break;
+        //        case "Z":
+        //        case "KZ":
+        //        case "Z(A)":
+        //        case "Z(B)":
+        //        case "Z_AM":
+        //        case "Z_BM":
+        //            ZSectionProfile profile = new ZSectionProfile();
+        //            break;
+        //        default:
+        //            break;
+        //    }
 
-            /* ---TODO: cannot find shape types for these profiles: 
-                BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
-                BH.oM.Geometry.ShapeProfiles.FabricatedISectionProfile
-                BH.oM.Geometry.ShapeProfiles.GeneralisedFabricatedBoxProfile
-                BH.oM.Geometry.ShapeProfiles.GeneralisedTSectionProfile
-                BH.oM.Geometry.ShapeProfiles.KiteProfile
-                BH.oM.Geometry.ShapeProfiles.TaperedProfile
-                */
+        //    /* ---TODO: cannot find shape types for these profiles: 
+        //        BH.oM.Geometry.ShapeProfiles.FabricatedBoxProfile
+        //        BH.oM.Geometry.ShapeProfiles.FabricatedISectionProfile
+        //        BH.oM.Geometry.ShapeProfiles.GeneralisedFabricatedBoxProfile
+        //        BH.oM.Geometry.ShapeProfiles.GeneralisedTSectionProfile
+        //        BH.oM.Geometry.ShapeProfiles.KiteProfile
+        //        BH.oM.Geometry.ShapeProfiles.TaperedProfile
+        //        */
 
-        }
+        //}
 
 
         /***************************************************/

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -46,6 +46,9 @@
       <HintPath>..\packages\BHoM.Interop.RFEM_5.1.0.0\lib\net45\Dlubal.DynamPro.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Dlubal.RFEM3, Version=3.4.0.0, Culture=neutral, PublicKeyToken=2168830b90cb4fa2, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Dlubal.RFEM5, Version=5.5.0.0, Culture=neutral, PublicKeyToken=f22b2f92593d105e, processorArchitecture=AMD64">
       <HintPath>..\packages\BHoM.Interop.RFEM_5.1.0.0\lib\net45\Dlubal.RFEM5.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -118,17 +121,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="RFEM3">
-      <Guid>{6A74CD4B-9D69-440A-9DB1-71D52658C9EA}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>4</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -119,6 +119,17 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="RFEM3">
+      <Guid>{6A74CD4B-9D69-440A-9DB1-71D52658C9EA}</Guid>
+      <VersionMajor>3</VersionMajor>
+      <VersionMinor>4</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -47,7 +47,9 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Dlubal.RFEM3, Version=3.4.0.0, Culture=neutral, PublicKeyToken=2168830b90cb4fa2, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\packages\BHoM.Interop.RFEM3.1.0.0\lib\net45\Dlubal.RFEM3.dll</HintPath>
     </Reference>
     <Reference Include="Dlubal.RFEM5, Version=5.5.0.0, Culture=neutral, PublicKeyToken=f22b2f92593d105e, processorArchitecture=AMD64">
       <HintPath>..\packages\BHoM.Interop.RFEM_5.1.0.0\lib\net45\Dlubal.RFEM5.dll</HintPath>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #39 
Closes #65 
Closes #27 
Closes #25 
Closes #24 

 <!-- Add short description of what has been fixed -->
material conversions now support all basic materials - not just standard steel
section properties now support steel, aluminium, timber and concrete.
reading section profiles from library
reading parametric defined section profiles
writing section profiles from library
writing parametric defined section profiles

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[RFEM file and GH file for testing](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/RFEM_Toolkit/ExtendedSectionProperties?csf=1&web=1&e=BNafae)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
