### PR TITLE
Remove reference and usings pointing to Common_oM and update namespace

### DIFF
--- a/RFEM_Adapter/AdapterActions/Pull.cs
+++ b/RFEM_Adapter/AdapterActions/Pull.cs
@@ -23,7 +23,6 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.Elements;
 using BH.oM.Base;
 using BH.oM.Data.Requests;

--- a/RFEM_Adapter/AdapterActions/Push.cs
+++ b/RFEM_Adapter/AdapterActions/Push.cs
@@ -23,7 +23,6 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.Elements;
 using BH.oM.Base;
 using BH.oM.Data.Requests;

--- a/RFEM_Adapter/CRUD/Create/Bar.cs
+++ b/RFEM_Adapter/CRUD/Create/Bar.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Create/Edge.cs
+++ b/RFEM_Adapter/CRUD/Create/Edge.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.RFEM;
 using BH.oM.Physical;

--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -26,7 +26,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.MaterialFragments;
-using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
 

--- a/RFEM_Adapter/CRUD/Create/Node.cs
+++ b/RFEM_Adapter/CRUD/Create/Node.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -28,7 +28,6 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Geometry;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
 using BH.Engine.RFEM;

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
-using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
 

--- a/RFEM_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
-using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
 

--- a/RFEM_Adapter/CRUD/Create/SurfaceProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SurfaceProperty.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
 using BH.Engine.RFEM;

--- a/RFEM_Adapter/CRUD/Create/_Create.cs
+++ b/RFEM_Adapter/CRUD/Create/_Create.cs
@@ -29,7 +29,6 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.SurfaceProperties;
-using BH.oM.Common.Materials;
 using BH.oM.Adapter;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Delete/_Remove.cs
+++ b/RFEM_Adapter/CRUD/Delete/_Remove.cs
@@ -26,7 +26,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using BH.Engine.RFEM;
 using BH.oM.Adapter;
 using BH.oM.Data.Requests;
 using rf = Dlubal.RFEM5;

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -31,7 +31,6 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
 
 using rf = Dlubal.RFEM5;
-using BH.Engine.RFEM;
 using BH.oM.Structure.MaterialFragments;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -29,7 +29,6 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
-using BH.oM.Common.Materials;
 
 using rf = Dlubal.RFEM5;
 using BH.Engine.RFEM;

--- a/RFEM_Adapter/CRUD/Read/Constraint.cs
+++ b/RFEM_Adapter/CRUD/Read/Constraint.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-using BH.Engine.RFEM;
+using BH.Engine.Adapters.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Read/Material.cs
+++ b/RFEM_Adapter/CRUD/Read/Material.cs
@@ -27,7 +27,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.MaterialFragments;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 

--- a/RFEM_Adapter/CRUD/Read/Material.cs
+++ b/RFEM_Adapter/CRUD/Read/Material.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;

--- a/RFEM_Adapter/CRUD/Read/Node.cs
+++ b/RFEM_Adapter/CRUD/Read/Node.cs
@@ -29,7 +29,6 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -29,7 +29,6 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
-using BH.oM.Common.Materials;
 
 using rf = Dlubal.RFEM5;
 using BH.Engine.RFEM;

--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -31,7 +31,6 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;
 
 using rf = Dlubal.RFEM5;
-using BH.Engine.RFEM;
 using BH.oM.Structure.MaterialFragments;
 
 namespace BH.Adapter.RFEM

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -28,7 +28,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.SectionProperties;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = RFEM3;
 

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -28,7 +28,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.SectionProperties;
-using BH.oM.Common.Materials;
 using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = RFEM3;

--- a/RFEM_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -28,7 +28,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.SurfaceProperties;
-using BH.oM.Common.Materials;
 using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = RFEM3;

--- a/RFEM_Adapter/CRUD/Read/SurfaceProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SurfaceProperty.cs
@@ -28,7 +28,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Structure.SurfaceProperties;
-using BH.Engine.RFEM;
+using BH.Engine.Adapters.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = RFEM3;
 using BH.oM.Structure.MaterialFragments;

--- a/RFEM_Adapter/CRUD/Read/_Read.cs
+++ b/RFEM_Adapter/CRUD/Read/_Read.cs
@@ -31,7 +31,6 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.SurfaceProperties;
-using BH.oM.Common.Materials;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Adapter;
 

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -30,7 +30,7 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
-using BH.Engine.RFEM;
+using BH.Engine.Adapters.RFEM;
 
 namespace BH.Adapter.RFEM
 {

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -31,7 +31,6 @@ using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.Engine.Structure;
-using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
 using rf3 = Dlubal.RFEM3;
@@ -72,7 +71,7 @@ namespace BH.Adapter.RFEM
 
 
             IMaterialFragment materialFragment = rfMaterial.FromRFEM();
-            IProfile profile = Engine.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
+            IProfile profile = Engine.Adapters.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
             if (profile != null)
             {
                 IGeometricalSection geoSection = Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 

--- a/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
@@ -30,7 +30,6 @@ using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
 using BH.Engine.Structure;
-using BH.Engine.RFEM;
 using BH.oM.Physical;
 using rf = Dlubal.RFEM5;
 

--- a/RFEM_Adapter/RFEMAdapter.cs
+++ b/RFEM_Adapter/RFEMAdapter.cs
@@ -38,7 +38,7 @@ using BH.oM.Reflection.Attributes;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Adapter;
-using BH.oM.Adapter.RFEM;
+using BH.oM.Adapters.RFEM;
 using BH.Engine.Base.Objects;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Constraints;

--- a/RFEM_Adapter/RFEMAdapter.cs
+++ b/RFEM_Adapter/RFEMAdapter.cs
@@ -31,7 +31,6 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
-using BH.oM.Common.Materials;
 using BH.oM.Structure.Elements;
 using BH.oM.Base;
 using BH.oM.Data.Requests;

--- a/RFEM_Adapter/RFEM_Adapter.csproj
+++ b/RFEM_Adapter/RFEM_Adapter.csproj
@@ -57,11 +57,6 @@
       <HintPath>..\..\BHoM_Engine\Build\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Common_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -28,11 +28,10 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
-using BH.Engine.RFEM;
 using BH.Engine.Structure;
 using rf = Dlubal.RFEM5;
 
-namespace BH.Engine.RFEM
+namespace BH.Engine.Adapters.RFEM
 {
     public static partial class Query
     {

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -29,12 +29,11 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 using rf3 = Dlubal.RFEM3;
 
 
-namespace BH.Engine.RFEM
+namespace BH.Engine.Adapters.RFEM
 {
     public static partial class Query
     {

--- a/RFEM_Engine/Query/SectionProperty.cs
+++ b/RFEM_Engine/Query/SectionProperty.cs
@@ -28,10 +28,9 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.SectionProperties;
-using BH.Engine.RFEM;
 using rf = Dlubal.RFEM5;
 
-namespace BH.Engine.RFEM
+namespace BH.Engine.Adapters.RFEM
 {
     public static partial class Query
     {

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{625C4A3B-A0AB-4B29-B289-4C439B565EFF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Engine.RFEM</RootNamespace>
+    <RootNamespace>BH.Engine.Adapters.RFEM</RootNamespace>
     <AssemblyName>RFEM_Engine</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -129,6 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Versioning_32.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -38,11 +38,6 @@
     <Reference Include="BHoM_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Common_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dlubal.DynamPro, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ad96acf4bd703704, processorArchitecture=AMD64">

--- a/RFEM_Engine/Versioning_32.json
+++ b/RFEM_Engine/Versioning_32.json
@@ -1,0 +1,20 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+			"BH.Engine.RFEM" : "BH.Engine.Adapters.RFEM"
+    },
+    "ToOld": {
+			"BH.Engine.Adapters.RFEM" : "BH.Engine.RFEM"
+    }
+  },
+  "Type": {
+    "ToNew": {
+	    
+
+    },
+    "ToOld": {
+
+
+    }
+  }
+} 

--- a/RFEM_oM/RFEMSettings.cs
+++ b/RFEM_oM/RFEMSettings.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using BH.oM.Adapter;
 using BH.oM.Base;
 
-namespace BH.oM.Adapter.RFEM
+namespace BH.oM.Adapters.RFEM
 {
     [Description("This Config can be specified in the `ActionConfig` input of any Adapter Action (e.g. Push).")]
     // Note: this will get passed within any CRUD method (see their signature). 

--- a/RFEM_oM/RFEM_oM.csproj
+++ b/RFEM_oM/RFEM_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -37,11 +37,6 @@
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Common_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">

--- a/RFEM_oM/RFEM_oM.csproj
+++ b/RFEM_oM/RFEM_oM.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{F55CC8A5-44CB-4333-BC8A-A0EB6775B1A8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.oM.Adapter.RFEM</RootNamespace>
+    <RootNamespace>BH.oM.Adapters.RFEM</RootNamespace>
     <AssemblyName>RFEM_oM</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -66,7 +66,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RFEMSettings.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Versioning_32.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/RFEM_oM/Versioning_32.json
+++ b/RFEM_oM/Versioning_32.json
@@ -1,0 +1,20 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+		"BH.oM.Adapter.RFEM" : "BH.oM.Adapters.RFEM"
+    },
+    "ToOld": {
+		"BH.oM.Adapters.RFEM" : "BH.oM.Adapter.RFEM"
+    }
+  },
+  "Type": {
+    "ToNew": {
+	    
+
+    },
+    "ToOld": {
+
+
+    }
+  }
+} 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #85 
Closes #87 

 <!-- Add short description of what has been fixed -->

- Remove reference and and usings pointing to the to-be-removed common_oM
- Change namespace of oM and Engine to include `Adapters`

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Etymz_3Y6etFr47o9037B_IBHgLoGeX9aJ-ks6krVFw__w?e=PP8frp

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
