### PR TITLE
Adding AdapterIdName to the FromRFEM methods where missing

### DIFF
--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -74,7 +74,7 @@ namespace BH.Adapter.RFEM
                         surfaceProperty = null;
                         Engine.Reflection.Compute.RecordError("could not create surface property of type " + surface.StiffnessType.ToString());
                     }
-
+                    
                     List<Opening> openings = null;
                     Panel panel = Engine.Structure.Create.Panel(edgeList, openings, surfaceProperty);
 

--- a/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
@@ -88,7 +88,7 @@ namespace BH.Adapter.RFEM
             else
                 bhConstraint.RotationalStiffnessZ = rfConstraint.RestraintConstantZ;
 
-
+            bhConstraint.CustomData[AdapterIdName] = rfConstraint.No;
             return bhConstraint;
         }
 

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -75,6 +75,7 @@ namespace BH.Adapter.RFEM
                     break;
             }
 
+            bhMaterial.CustomData[AdapterIdName] = material.No;
             return bhMaterial;
         }
 

--- a/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
@@ -92,9 +92,8 @@ namespace BH.Adapter.RFEM
                     break;
             }
 
+            surfaceProperty.CustomData[AdapterIdName] = rfStiffness.No;
             return surfaceProperty;
-
-
 
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.RFEM
             rfSectionProperty.BendingMomentZ = sectionProperty.Iz;
 
             name = sectionProperty.DescriptionOrName();
-
+            
             rfSectionProperty.Description = name;
             rfSectionProperty.TextID = name;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #92 

 <!-- Add short description of what has been fixed -->

Making sure that AdapterIdName is correctly assigned on read for all property objects where previously missing.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Testfiles from general testing procedures to be used

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
