### PR TITLE
Tapered sections

### DIFF
--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
-
+using BH.Engine.Spatial;
 using rf = Dlubal.RFEM5;
 using BH.oM.Structure.MaterialFragments;
 
@@ -66,6 +66,41 @@ namespace BH.Adapter.RFEM
                         sectionProperty = rfISection.FromRFEM(rfMat);
                         m_sectionDict.Add(member.StartCrossSectionNo, sectionProperty);
                     }
+
+                    //check for tapered section
+                    if(member.EndCrossSectionNo!=0)
+                    {
+                        ISectionProperty startSectionProperty = sectionProperty;
+                        ISectionProperty endSectionProperty;
+
+
+                        if (!m_sectionDict.TryGetValue(member.EndCrossSectionNo, out endSectionProperty))
+                        {
+                            rf.ICrossSection rfISection = modelData.GetCrossSection(member.EndCrossSectionNo, rf.ItemAt.AtNo);
+                            rf.CrossSection rfSection = rfISection.GetData();
+                            rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
+                            endSectionProperty = rfISection.FromRFEM(rfMat);
+                            m_sectionDict.Add(member.EndCrossSectionNo, endSectionProperty);
+                        }
+
+                        //check if section mixex material !!!
+                        if(startSectionProperty.Material.Name != endSectionProperty.Material.Name)//campare by name as comparing materials seems to always be not equal
+                            Engine.Reflection.Compute.RecordWarning("Tapered section mixes materials. Material from start of section is used");
+
+                        oM.Spatial.ShapeProfiles.IProfile taperProfile = null;
+
+                        if (startSectionProperty.Material.GetType() == typeof(Steel))
+                        {
+                            SteelSection startSection = startSectionProperty as SteelSection;
+                            SteelSection endSection = endSectionProperty as SteelSection;
+                            taperProfile = BH.Engine.Spatial.Create.TaperedProfile(startSection.SectionProfile, endSection.SectionProfile);
+                            taperProfile.Name = "TaperedProfile-" + startSection.Name + "-To-" + endSection.Name;
+                        }
+
+                        sectionProperty = BH.Engine.Structure.Create.SectionPropertyFromProfile(taperProfile, startSectionProperty.Material);
+
+                    }
+
 
                     barList.Add(member.FromRFEM(line, sectionProperty));
                 }

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -73,7 +73,6 @@ namespace BH.Adapter.RFEM
                         ISectionProperty startSectionProperty = sectionProperty;
                         ISectionProperty endSectionProperty;
 
-
                         if (!m_sectionDict.TryGetValue(member.EndCrossSectionNo, out endSectionProperty))
                         {
                             rf.ICrossSection rfISection = modelData.GetCrossSection(member.EndCrossSectionNo, rf.ItemAt.AtNo);
@@ -97,8 +96,23 @@ namespace BH.Adapter.RFEM
                             taperProfile.Name = "TaperedProfile-" + startSection.Name + "-To-" + endSection.Name;
                         }
 
-                        sectionProperty = BH.Engine.Structure.Create.SectionPropertyFromProfile(taperProfile, startSectionProperty.Material);
+                        if (startSectionProperty.Material.GetType() == typeof(Concrete))
+                        {
+                            ConcreteSection startSection = startSectionProperty as ConcreteSection;
+                            ConcreteSection endSection = endSectionProperty as ConcreteSection;
+                            taperProfile = BH.Engine.Spatial.Create.TaperedProfile(startSection.SectionProfile, endSection.SectionProfile);
+                            taperProfile.Name = "TaperedProfile-" + startSection.Name + "-To-" + endSection.Name;
+                        }
 
+                        if (startSectionProperty.Material.GetType() == typeof(Timber))
+                        {
+                            TimberSection startSection = startSectionProperty as TimberSection;
+                            TimberSection endSection = endSectionProperty as TimberSection;
+                            taperProfile = BH.Engine.Spatial.Create.TaperedProfile(startSection.SectionProfile, endSection.SectionProfile);
+                            taperProfile.Name = "TaperedProfile-" + startSection.Name + "-To-" + endSection.Name;
+                        }
+
+                        sectionProperty = BH.Engine.Structure.Create.SectionPropertyFromProfile(taperProfile, startSectionProperty.Material);
                     }
 
 

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -53,7 +53,11 @@ namespace BH.Adapter.RFEM
             {
                 foreach (rf.Member member in modelData.GetMembers())
                 {
-                    if (member.Type == rf.MemberType.Rigid | member.Type == rf.MemberType.CouplingHingeHinge | member.Type == rf.MemberType.CouplingHingeRigid | member.Type == rf.MemberType.CouplingRigidHinge | member.Type == rf.MemberType.CouplingRigidRigid)
+                    if (member.Type == rf.MemberType.Rigid |
+                        member.Type == rf.MemberType.CouplingHingeHinge |
+                        member.Type == rf.MemberType.CouplingHingeRigid |
+                        member.Type == rf.MemberType.CouplingRigidHinge |
+                        member.Type == rf.MemberType.CouplingRigidRigid)
                         continue;
                     
                     line = modelData.GetLine(member.LineNo, rf.ItemAt.AtNo).GetData();
@@ -68,8 +72,8 @@ namespace BH.Adapter.RFEM
                         secondSectionNo = member.EndCrossSectionNo;
                     }
 
-                    if (firstSectionNo == 0 & secondSectionNo == 0)
-                        firstSectionNo = 1;
+                    if (firstSectionNo == secondSectionNo)
+                        secondSectionNo = 0;
 
                     sectionProperty = GetSectionProperty(firstSectionNo);
 

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -53,18 +53,31 @@ namespace BH.Adapter.RFEM
             {
                 foreach (rf.Member member in modelData.GetMembers())
                 {
-                    if (member.Type == rf.MemberType.Rigid)
+                    if (member.Type == rf.MemberType.Rigid | member.Type == rf.MemberType.CouplingHingeHinge | member.Type == rf.MemberType.CouplingHingeRigid | member.Type == rf.MemberType.CouplingRigidHinge | member.Type == rf.MemberType.CouplingRigidRigid)
                         continue;
-
+                    
                     line = modelData.GetLine(member.LineNo, rf.ItemAt.AtNo).GetData();
+                    int firstSectionNo = 0;
+                    int secondSectionNo = 0;
 
-                    sectionProperty = GetSectionProperty(member.StartCrossSectionNo);
+                    if (member.StartCrossSectionNo == 0 & member.EndCrossSectionNo != 0)
+                        firstSectionNo = member.EndCrossSectionNo;
+                    else
+                    {
+                        firstSectionNo = member.StartCrossSectionNo;
+                        secondSectionNo = member.EndCrossSectionNo;
+                    }
+
+                    if (firstSectionNo == 0 & secondSectionNo == 0)
+                        firstSectionNo = 1;
+
+                    sectionProperty = GetSectionProperty(firstSectionNo);
 
                     //check for tapered section
-                    if(member.EndCrossSectionNo!=0)
+                    if(secondSectionNo != 0)
                     {
                         ISectionProperty startSectionProperty = sectionProperty;
-                        ISectionProperty endSectionProperty = GetSectionProperty(member.EndCrossSectionNo);
+                        ISectionProperty endSectionProperty = GetSectionProperty(secondSectionNo);
                         sectionProperty = GetTaperedSectionProperty(startSectionProperty, endSectionProperty);
                     }
 
@@ -81,13 +94,24 @@ namespace BH.Adapter.RFEM
                         continue;
 
                     line = modelData.GetLine(member.LineNo, rf.ItemAt.AtNo).GetData();
+                    int firstSectionNo = 0;
+                    int secondSectionNo = 0;
 
-                    sectionProperty = GetSectionProperty(member.StartCrossSectionNo);
+                    if (member.StartCrossSectionNo == 0 & member.EndCrossSectionNo != 0)
+                        firstSectionNo = member.EndCrossSectionNo;
+                    else
+                    {
+                        firstSectionNo = member.StartCrossSectionNo;
+                        secondSectionNo = member.EndCrossSectionNo;
+                    }
 
-                    if (member.EndCrossSectionNo != 0)
+                    sectionProperty = GetSectionProperty(firstSectionNo);
+
+                    //check for tapered section
+                    if (secondSectionNo != 0)
                     {
                         ISectionProperty startSectionProperty = sectionProperty;
-                        ISectionProperty endSectionProperty = GetSectionProperty(member.EndCrossSectionNo);
+                        ISectionProperty endSectionProperty = GetSectionProperty(secondSectionNo);
                         sectionProperty = GetTaperedSectionProperty(startSectionProperty, endSectionProperty);
                     }
 

--- a/RFEM_Adapter/CRUD/Read/Bar.cs
+++ b/RFEM_Adapter/CRUD/Read/Bar.cs
@@ -58,33 +58,17 @@ namespace BH.Adapter.RFEM
 
                     line = modelData.GetLine(member.LineNo, rf.ItemAt.AtNo).GetData();
 
-                    if (!m_sectionDict.TryGetValue(member.StartCrossSectionNo, out sectionProperty))
-                    {
-                        rf.ICrossSection rfISection = modelData.GetCrossSection(member.StartCrossSectionNo, rf.ItemAt.AtNo);
-                        rf.CrossSection rfSection = rfISection.GetData();
-                        rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                        sectionProperty = rfISection.FromRFEM(rfMat);
-                        m_sectionDict.Add(member.StartCrossSectionNo, sectionProperty);
-                    }
+                    sectionProperty = GetSectionProperty(member.StartCrossSectionNo);
 
                     //check for tapered section
                     if(member.EndCrossSectionNo!=0)
                     {
                         ISectionProperty startSectionProperty = sectionProperty;
-                        ISectionProperty endSectionProperty;
+                        ISectionProperty endSectionProperty = GetSectionProperty(member.EndCrossSectionNo);
 
-                        if (!m_sectionDict.TryGetValue(member.EndCrossSectionNo, out endSectionProperty))
-                        {
-                            rf.ICrossSection rfISection = modelData.GetCrossSection(member.EndCrossSectionNo, rf.ItemAt.AtNo);
-                            rf.CrossSection rfSection = rfISection.GetData();
-                            rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
-                            endSectionProperty = rfISection.FromRFEM(rfMat);
-                            m_sectionDict.Add(member.EndCrossSectionNo, endSectionProperty);
-                        }
-
-                        //check if section mixex material !!!
+                        //check if section mixes material !!!
                         if(startSectionProperty.Material.Name != endSectionProperty.Material.Name)//campare by name as comparing materials seems to always be not equal
-                            Engine.Reflection.Compute.RecordWarning("Tapered section mixes materials. Material from start of section is used");
+                            Engine.Reflection.Compute.RecordWarning("Tapered section mixes materials. Only material from start of section is used");
 
                         oM.Spatial.ShapeProfiles.IProfile taperProfile = null;
 
@@ -149,6 +133,21 @@ namespace BH.Adapter.RFEM
 
         /***************************************************/
 
+        private ISectionProperty GetSectionProperty(int crossSectionNumber)
+        {
+            ISectionProperty sectionProperty;
+
+            if (!m_sectionDict.TryGetValue(crossSectionNumber, out sectionProperty))
+            {
+                rf.ICrossSection rfISection = modelData.GetCrossSection(crossSectionNumber, rf.ItemAt.AtNo);
+                rf.CrossSection rfSection = rfISection.GetData();
+                rf.Material rfMat = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
+                sectionProperty = rfISection.FromRFEM(rfMat);
+                m_sectionDict.Add(crossSectionNumber, sectionProperty);
+            }
+
+            return sectionProperty;
+        }
     }
 }
 

--- a/RFEM_Adapter/CRUD/Read/RigidLink.cs
+++ b/RFEM_Adapter/CRUD/Read/RigidLink.cs
@@ -50,7 +50,11 @@ namespace BH.Adapter.RFEM
 
             if (ids == null)
             {
-                rf.Member[] allLinks = modelData.GetMembers().Where(x => x.Type == rf.MemberType.Rigid).ToArray();
+                rf.Member[] allLinks = modelData.GetMembers().Where(x => x.Type == rf.MemberType.Rigid)
+                    .Where(x => x.Type == rf.MemberType.CouplingHingeHinge)
+                    .Where(x => x.Type == rf.MemberType.CouplingHingeRigid)
+                    .Where(x => x.Type == rf.MemberType.CouplingRigidHinge)
+                    .Where(x => x.Type == rf.MemberType.CouplingRigidRigid).ToArray();
 
                 foreach (rf.Member link in allLinks)
                 {
@@ -86,7 +90,7 @@ namespace BH.Adapter.RFEM
                 {
                     rf.Member link = modelData.GetMember(Int32.Parse(id), rf.ItemAt.AtNo).GetData();
 
-                    if (link.Type != rf.MemberType.Rigid)
+                    if (link.Type != rf.MemberType.Rigid | link.Type != rf.MemberType.CouplingHingeHinge | link.Type != rf.MemberType.CouplingHingeRigid | link.Type != rf.MemberType.CouplingRigidHinge | link.Type != rf.MemberType.CouplingRigidRigid)
                         continue;
 
                     line = modelData.GetLine(link.LineNo, rf.ItemAt.AtNo).GetData();

--- a/RFEM_Adapter/CRUD/Read/RigidLink.cs
+++ b/RFEM_Adapter/CRUD/Read/RigidLink.cs
@@ -50,11 +50,11 @@ namespace BH.Adapter.RFEM
 
             if (ids == null)
             {
-                rf.Member[] allLinks = modelData.GetMembers().Where(x => x.Type == rf.MemberType.Rigid)
-                    .Where(x => x.Type == rf.MemberType.CouplingHingeHinge)
-                    .Where(x => x.Type == rf.MemberType.CouplingHingeRigid)
-                    .Where(x => x.Type == rf.MemberType.CouplingRigidHinge)
-                    .Where(x => x.Type == rf.MemberType.CouplingRigidRigid).ToArray();
+                rf.Member[] allLinks = modelData.GetMembers().Where(x => (x.Type == rf.MemberType.Rigid) |
+                    (x.Type == rf.MemberType.CouplingHingeHinge) |
+                    (x.Type == rf.MemberType.CouplingHingeRigid) |
+                    (x.Type == rf.MemberType.CouplingRigidHinge) |
+                    (x.Type == rf.MemberType.CouplingRigidRigid)).ToArray();
 
                 foreach (rf.Member link in allLinks)
                 {

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.RFEM
             IMaterialFragment bhMaterial = null;
 
             string[] stringArr = material.TextID.Split('@');
-            MaterialType matType = Engine.Adapters.RFEM.Query.GetMaterialType(material);
+            MaterialType matType = material.GetMaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
             string matName = Engine.Adapters.RFEM.Query.GetMaterialName(material);
 
             switch (matType)

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -101,6 +101,7 @@ namespace BH.Adapter.RFEM
 
         }
 
+
     }
 }
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -73,7 +73,7 @@ namespace BH.Adapter.RFEM
 
 
             IMaterialFragment materialFragment = rfMaterial.FromRFEM();
-            IProfile profile = Engine.Adapters.RFEM.Query.GetSectionProfile(sectionName, sectionDBProps);
+            IProfile profile = Engine.Adapters.RFEM.Compute.GetSectionProfile(sectionName, sectionDBProps);
             if (profile != null)
             {
                 IGeometricalSection geoSection = Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 

--- a/RFEM_Adapter/Convert/ToRFEM/Bar.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Bar.cs
@@ -45,7 +45,6 @@ namespace BH.Adapter.RFEM
             rf.Member rfBar = new rf.Member();
             rfBar.No = barId;
             rfBar.LineNo = lineId;
-
             rfBar.StartCrossSectionNo = bar.SectionProperty.AdapterId<int>(typeof(RFEMId));
 
             rf.Rotation rotation = new rf.Rotation();

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -31,7 +31,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Spatial.ShapeProfiles;
 using rf = Dlubal.RFEM5;
 using rf3 = Dlubal.RFEM3;
-
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Adapters.RFEM
 {
@@ -40,7 +40,7 @@ namespace BH.Engine.Adapters.RFEM
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
+        [PreviousVersion("4.2", "BH.Engine.Adapters.RFEM.Query.GetSectionProfile(System.String, Dlubal.RFEM3.DB_CRSC_PROPERTY[])")]
         public static IProfile GetSectionProfile(string profileName, rf3.DB_CRSC_PROPERTY[] sectionDBProps = null)
         {
             // standard section name: SHS 25x25x2

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -35,7 +35,7 @@ using rf3 = Dlubal.RFEM3;
 
 namespace BH.Engine.Adapters.RFEM
 {
-    public static partial class Query
+    public static partial class Compute
     {
         /***************************************************/
         /**** Public Methods                            ****/

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Adapters.RFEM
         //Format: NameID|material ID@TypeID|material type@NormID|material code
         //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
 
-        public static MaterialType GetMaterialType(rf.Material rfMaterial)
+        public static MaterialType GetMaterialType(this rf.Material rfMaterial)
         {
             string[] materialString = rfMaterial.TextID.Split('@');
 

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -72,6 +72,7 @@ namespace BH.Engine.Adapters.RFEM
                     case "HE":
                     case "HEA":
                     case "HEB":
+                    case "HEM":
                     case "UB":
                     case "UBP":
                     case "UC":

--- a/RFEM_Engine/Query/Profile.cs
+++ b/RFEM_Engine/Query/Profile.cs
@@ -245,7 +245,7 @@ namespace BH.Engine.Adapters.RFEM
                     //    profile = new ZSectionProfile(v1, v2, v3, v4, v5, v6, "< looks like the only way to create this now is to use the profile curves !! >");
                     //    break;
                     default:
-                        Engine.Reflection.Compute.RecordError("Don't know how to make profile " + profileName);
+                        Engine.Reflection.Compute.RecordError("Don't know how to make profile: " + profileName);
                         break;
                 }
             }

--- a/RFEM_Engine/Query/SectionProperty.cs
+++ b/RFEM_Engine/Query/SectionProperty.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Adapters.RFEM
         /***************************************************/
 
 
-        public static Type GetSectionType(rf.CrossSection rfSectionProperty)
+        public static Type GetSectionType(this rf.CrossSection rfSectionProperty)
         {
             string[] propertyString = rfSectionProperty.TextID.Split('@');
 

--- a/RFEM_Engine/RFEM_Engine.csproj
+++ b/RFEM_Engine/RFEM_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -32,12 +32,12 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dlubal.DynamPro, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ad96acf4bd703704, processorArchitecture=AMD64">
@@ -63,26 +63,26 @@
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
-<HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Spatial_Engine">
@@ -95,12 +95,12 @@
     </Reference>
     <Reference Include="Structure_Engine">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Structure_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Structure_oM">
       <SpecificVersion>False</SpecificVersion>
-<HintPath>C:\ProgramData\BHoM\Assemblies\Structure_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -115,11 +115,10 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\Material.cs" />
-    <Compile Include="Query\Profile.cs" />
+    <Compile Include="Compute\Profile.cs" />
     <Compile Include="Query\SectionProperty.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Compute\" />
     <Folder Include="Convert\" />
     <Folder Include="Modify\" />
   </ItemGroup>


### PR DESCRIPTION

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #
closes #115 
closes #116 

 <!-- Add short description of what has been fixed -->
added feature to read tapered sections from RFEM and fixed bug when reading rigidlinks with coupling type set. 

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[test file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/RFEM_Toolkit-TaperedSections.gh?csf=1&web=1&e=aHHTK5)
RFEM file not shared here due to confidentiality

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
added feature: read tapered sections
fixed bug: rigid link with type coupling


