### PR TITLE
Read-Write Name property on structural elements

### DIFF
--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -77,6 +77,7 @@ namespace BH.Adapter.RFEM
                     
                     List<Opening> openings = null;
                     Panel panel = Engine.Structure.Create.Panel(edgeList, openings, surfaceProperty);
+                    panel.Name = surface.Comment;
 
                     panelList.Add(panel);
                 }

--- a/RFEM_Adapter/Convert/FromRFEM/Bar.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Bar.cs
@@ -49,7 +49,8 @@ namespace BH.Adapter.RFEM
             BH.oM.Geometry.Line ln = new oM.Geometry.Line() { Start = new oM.Geometry.Point() { X = sPt.X, Y = sPt.Y, Z = sPt.Z }, End = new oM.Geometry.Point() { X = ePt.X, Y = ePt.Y, Z = ePt.Z } };
 
             Bar bhBar = BH.Engine.Structure.Create.Bar(ln, sectionProperty, member.Rotation.Angle);
-            
+            bhBar.Name = member.Comment;
+
             bhBar.SetAdapterId(typeof(RFEMId), member.No);
             return bhBar;
         }

--- a/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
@@ -45,6 +45,9 @@ namespace BH.Adapter.RFEM
         {
             Constraint6DOF bhConstraint = new Constraint6DOF();
 
+            
+            bhConstraint.Name = rfConstraint.Comment;
+
             //Translation
             if (rfConstraint.SupportConstantX == 0)
                 bhConstraint.TranslationX = DOFType.Free;
@@ -89,7 +92,10 @@ namespace BH.Adapter.RFEM
             else
                 bhConstraint.RotationalStiffnessZ = rfConstraint.RestraintConstantZ;
 
+           
+          
             bhConstraint.SetAdapterId(typeof(RFEMId), rfConstraint.No);
+
             return bhConstraint;
         }
 

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -76,6 +76,9 @@ namespace BH.Adapter.RFEM
                 default:
                     break;
             }
+           
+         
+            bhMaterial.Name = material.Comment;
 
             bhMaterial.SetAdapterId(typeof(RFEMId), material.No);
             return bhMaterial;

--- a/RFEM_Adapter/Convert/FromRFEM/Node.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Node.cs
@@ -44,6 +44,9 @@ namespace BH.Adapter.RFEM
             Node bhNode = new Node { Position = new oM.Geometry.Point() { X = node.X, Y = node.Y, Z = node.Z } };
             bhNode.SetAdapterId(typeof(RFEMId), node.No);
 
+           
+            bhNode.Name = node.Comment;
+
             return bhNode;
         }
 

--- a/RFEM_Adapter/Convert/FromRFEM/Panel.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Panel.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.RFEM
 
         public static Panel FromRFEM(this rf.Surface surface, ISurfaceProperty surfaceProperty)
         {
-
+            //TODO: this is not currently being called from "ReadPanels" - move relevant conversions to this extension method
             ICurve outline = null;
 
             string[] boundLineList = surface.BoundaryLineList.Split(',');
@@ -51,6 +51,7 @@ namespace BH.Adapter.RFEM
             Panel bhPanel = Engine.Structure.Create.Panel(outline,openings,surfaceProperty);
 
             bhPanel.SetAdapterId(typeof(RFEMId), surface.No);
+
 
             return bhPanel;
         }

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -50,6 +50,12 @@ namespace BH.Adapter.RFEM
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
 
             string sectionName = rfSectionProperty.Description;
+            sectionName.GetType().ToString();
+
+            
+
+
+
             rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
             object libraryObj = null;
 
@@ -79,6 +85,8 @@ namespace BH.Adapter.RFEM
                 IGeometricalSection geoSection = BH.Engine.Structure.Create.SectionPropertyFromProfile(profile, materialFragment, rfSectionProperty.TextID);// this creates the right property if the right material is provided 
                 geoSection.SetAdapterId(typeof(RFEMId), rfSectionProperty.No);
                 geoSection.Name = rfSectionProperty.TextID;
+                 
+
 
                 return geoSection;
             }
@@ -94,6 +102,8 @@ namespace BH.Adapter.RFEM
                 expSection.Iz = rfSectionProperty.BendingMomentZ;
                 expSection.SetAdapterId(typeof(RFEMId), rfSectionProperty.No);
                 expSection.Name = rfSectionProperty.TextID;
+                
+                
                 return expSection;
             }
 

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -50,7 +50,6 @@ namespace BH.Adapter.RFEM
             rf.CrossSection rfSectionProperty = rfISectionProperty.GetData();
 
             string sectionName = rfSectionProperty.Description;
-            sectionName.GetType().ToString();
 
             
 

--- a/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SurfaceProperty.cs
@@ -94,6 +94,8 @@ namespace BH.Adapter.RFEM
                     break;
             }
 
+
+            surfaceProperty.Name = rfStiffness.Comment;
             surfaceProperty.SetAdapterId(typeof(RFEMId), rfStiffness.No);
             return surfaceProperty;
 

--- a/RFEM_Adapter/Convert/ToRFEM/Bar.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Bar.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.RFEM
             rotation.Angle = bar.OrientationAngle;
             rotation.Type = rf.RotationType.Angle;
             rfBar.Rotation = rotation;
-
+            rfBar.Comment = bar.Name;
 
             return rfBar;
         }

--- a/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
@@ -87,6 +87,8 @@ namespace BH.Adapter.RFEM
             else
                 rfConstraint.RestraintConstantZ = constraint.RotationalStiffnessZ;
 
+         
+           
 
             return rfConstraint;
         }

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -111,6 +111,8 @@ namespace BH.Adapter.RFEM
 
             }
 
+            rfMaterial.Comment = materialFragment.Name;
+
             return rfMaterial;
 
         }

--- a/RFEM_Adapter/Convert/ToRFEM/Node.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Node.cs
@@ -41,6 +41,10 @@ namespace BH.Adapter.RFEM
             rfNode.Y = node.Position.Y;
             rfNode.Z = node.Position.Z;
             rfNode.Comment = node.Name;
+
+            rfNode.Comment = node.Name;
+
+
             return rfNode;
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/Node.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Node.cs
@@ -40,6 +40,7 @@ namespace BH.Adapter.RFEM
             rfNode.X = node.Position.X;
             rfNode.Y = node.Position.Y;
             rfNode.Z = node.Position.Z;
+            rfNode.Comment = node.Name;
             return rfNode;
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/Node.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Node.cs
@@ -42,9 +42,6 @@ namespace BH.Adapter.RFEM
             rfNode.Z = node.Position.Z;
             rfNode.Comment = node.Name;
 
-            rfNode.Comment = node.Name;
-
-
             return rfNode;
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/Panel.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Panel.cs
@@ -63,6 +63,8 @@ namespace BH.Adapter.RFEM
             }
 
 
+            rfSurface.Comment = panel.Name;
+
             return rfSurface;
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -61,7 +61,6 @@ namespace BH.Adapter.RFEM
 
             rfSectionProperty.Description = name;
             rfSectionProperty.TextID = name;
-            rfSectionProperty.Description = name;
             rfSectionProperty.Comment = sectionProperty.Name;
 
             return rfSectionProperty;

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -54,8 +54,15 @@ namespace BH.Adapter.RFEM
 
             name = sectionProperty.DescriptionOrName();
             
+            
+            //TODO 
+            // The CrossSection class does both use the attribute name and discribtion. 
+            // The Grasshopper interface does only know name
+
             rfSectionProperty.Description = name;
             rfSectionProperty.TextID = name;
+            rfSectionProperty.Description = name;
+            rfSectionProperty.Comment = sectionProperty.Name;
 
             return rfSectionProperty;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SurfaceProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SurfaceProperty.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.RFEM
         {
             rf.SurfaceStiffness stiffness = new rf.SurfaceStiffness();
 
-
+            
 
             if (surfaceProperty is LoadingPanelProperty)
             {
@@ -118,6 +118,8 @@ namespace BH.Adapter.RFEM
                 }
 
             }
+            stiffness.Comment = surfaceProperty.Name;
+
             return stiffness;
 
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #18

 <!-- Add short description of what has been fixed -->
For the Push and Pull between GH and RFEM a name property has been added in RFEM (can be seen in the comment section) for instances of Bar, Constraint, Material, Node and Panel. The name property can now be set RFEM and pulled into GH or vice versa.

Two Test files have been added (ToRFEM and FromRFEM). The From RFEM does also require an RFEM file, All files can be found under the link below.


 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRFEM%5FToolkit%2FIssue18%5Ffiles&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b)


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Read/Write Name property added to Structural elements in RFEM_Toolkit

 ### Additional comments
<!-- As required -->
