### PR TITLE
Adding null check for create method in rfem toolkit

### DIFF
--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -34,7 +34,6 @@ namespace BH.Adapter.RFEM
 {
     public partial class RFEMAdapter
     {
-        String test = "Test";
         /***************************************************/
         /**** Private methods                           ****/
         /***************************************************/
@@ -49,6 +48,16 @@ namespace BH.Adapter.RFEM
 
                 for (int i = 0; i < panels.Count(); i++)
                 {
+                   
+
+                    if (panelList.ElementAt(i).Property == null)
+                    {
+                        Engine.Base.Compute.RecordError("Could not create surface due to missing property in the panel "+ panelList.ElementAt(i).Name);
+                        continue;
+                    }
+                    
+
+
                     panelIdNum = GetAdapterId<int>(panelList[i]);
 
                     //get ids outside of BHoM process - might need to be changed

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.RFEM
 {
     public partial class RFEMAdapter
     {
-
+        String test = "Test";
         /***************************************************/
         /**** Private methods                           ****/
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #132 

 <!-- Add short description of what has been fixed -->
A push of a panel from GH into a surface in RFEM is only possible when a property has been added to the panel in GH. Previously the push node did give an error when trying to push but did not indicate why the push was not done. Now the push node is giving the user information about the missing property.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[File](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/RFEM_Toolkit-AddingNullCheckSurfacePush.gh)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Adding null check for create method in RFEM_toolkit for panels. 

 ### Additional comments
<!-- As required -->
