### PR TITLE
Fix Pull/Push of Constraint6DOF and added null check for panel property on push

### DIFF
--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -49,6 +49,13 @@ namespace BH.Adapter.RFEM
 
                 for (int i = 0; i < panels.Count(); i++)
                 {
+
+                    if (panelList.ElementAt(i).Property == null)
+                    {
+                        Engine.Base.Compute.RecordError("Could not create surface due to missing property in the panel " + panelList.ElementAt(i).Name);
+                        continue;
+                    }
+
                     panelIdNum = GetAdapterId<int>(panelList[i]);
 
                     //get ids outside of BHoM process - might need to be changed

--- a/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
@@ -48,52 +48,109 @@ namespace BH.Adapter.RFEM
             
             bhConstraint.Name = rfConstraint.Comment;
 
-            //Translation
+            //Translation x
             if (rfConstraint.SupportConstantX == 0)
+            {
                 bhConstraint.TranslationX = DOFType.Free;
-            if (rfConstraint.SupportConstantX == -1)
+                bhConstraint.TranslationalStiffnessX = 0;
+            }
+            else if (rfConstraint.SupportConstantX == -1)
+            {
                 bhConstraint.TranslationX = DOFType.Fixed;
+                bhConstraint.TranslationalStiffnessX = -1;
+            }
             else
+            {
                 bhConstraint.TranslationalStiffnessX = rfConstraint.SupportConstantX;
-
+                bhConstraint.TranslationX = DOFType.Spring;
+            }
+            //Translation Y
             if (rfConstraint.SupportConstantY == 0)
+            {
                 bhConstraint.TranslationY = DOFType.Free;
-            if (rfConstraint.SupportConstantY == -1)
+                bhConstraint.TranslationalStiffnessY = 0;
+            }
+            else if (rfConstraint.SupportConstantY == -1)
+            {
                 bhConstraint.TranslationY = DOFType.Fixed;
+                bhConstraint.TranslationalStiffnessY = -1;
+            }
             else
+            {
                 bhConstraint.TranslationalStiffnessY = rfConstraint.SupportConstantY;
-
+                bhConstraint.TranslationY = DOFType.Spring;
+            }
+            //Translation Z
             if (rfConstraint.SupportConstantZ == 0)
+            {
                 bhConstraint.TranslationZ = DOFType.Free;
-            if (rfConstraint.SupportConstantZ == -1)
+                bhConstraint.TranslationalStiffnessZ = 0;
+            }
+            else if (rfConstraint.SupportConstantZ == -1)
+            {
                 bhConstraint.TranslationZ = DOFType.Fixed;
+                bhConstraint.TranslationalStiffnessZ = -1;
+            }
             else
-                bhConstraint.TranslationalStiffnessZ = rfConstraint.SupportConstantZ;
+            {
+                bhConstraint.TranslationalStiffnessX = rfConstraint.SupportConstantZ;
+                bhConstraint.TranslationZ = DOFType.Spring;
+            }
 
-            //Rotation
+
+
+            //Rotation X
             if (rfConstraint.RestraintConstantX == 0)
+            {
                 bhConstraint.RotationX = DOFType.Free;
-            if (rfConstraint.RestraintConstantX == -1)
+                bhConstraint.RotationalStiffnessX = 0;
+            }
+            else if (rfConstraint.RestraintConstantX == -1)
+            {
                 bhConstraint.RotationX = DOFType.Fixed;
+                bhConstraint.RotationalStiffnessX = -1;
+            }
             else
+            {
                 bhConstraint.RotationalStiffnessX = rfConstraint.RestraintConstantX;
+                bhConstraint.RotationX = DOFType.Spring;
+            }
 
+            //Rotation Y
             if (rfConstraint.RestraintConstantY == 0)
+            {
                 bhConstraint.RotationY = DOFType.Free;
-            if (rfConstraint.RestraintConstantY == -1)
+                bhConstraint.RotationalStiffnessY = 0;
+            }
+            else if (rfConstraint.RestraintConstantY == -1)
+            {
                 bhConstraint.RotationY = DOFType.Fixed;
+                bhConstraint.RotationalStiffnessY = -1;
+            }
             else
+            {
                 bhConstraint.RotationalStiffnessY = rfConstraint.RestraintConstantY;
+                bhConstraint.RotationY = DOFType.Spring;
+            }
 
+            //Rotation Z
             if (rfConstraint.RestraintConstantZ == 0)
+            {
                 bhConstraint.RotationZ = DOFType.Free;
-            if (rfConstraint.RestraintConstantZ == -1)
+                bhConstraint.RotationalStiffnessZ = 0;
+            }
+            else if (rfConstraint.RestraintConstantZ == -1)
+            {
                 bhConstraint.RotationZ = DOFType.Fixed;
+                bhConstraint.RotationalStiffnessZ = -1;
+            }
             else
+            {
                 bhConstraint.RotationalStiffnessZ = rfConstraint.RestraintConstantZ;
+                bhConstraint.RotationZ = DOFType.Spring;
+            }
 
-           
-          
+
             bhConstraint.SetAdapterId(typeof(RFEMId), rfConstraint.No);
 
             return bhConstraint;

--- a/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Constraint.cs
@@ -45,19 +45,19 @@ namespace BH.Adapter.RFEM
         {
             Constraint6DOF bhConstraint = new Constraint6DOF();
 
-            
+
             bhConstraint.Name = rfConstraint.Comment;
 
             //Translation x
             if (rfConstraint.SupportConstantX == 0)
             {
                 bhConstraint.TranslationX = DOFType.Free;
-                bhConstraint.TranslationalStiffnessX = 0;
             }
             else if (rfConstraint.SupportConstantX == -1)
             {
                 bhConstraint.TranslationX = DOFType.Fixed;
-                bhConstraint.TranslationalStiffnessX = -1;
+
+
             }
             else
             {
@@ -68,12 +68,12 @@ namespace BH.Adapter.RFEM
             if (rfConstraint.SupportConstantY == 0)
             {
                 bhConstraint.TranslationY = DOFType.Free;
-                bhConstraint.TranslationalStiffnessY = 0;
             }
             else if (rfConstraint.SupportConstantY == -1)
             {
                 bhConstraint.TranslationY = DOFType.Fixed;
-                bhConstraint.TranslationalStiffnessY = -1;
+
+
             }
             else
             {
@@ -84,16 +84,16 @@ namespace BH.Adapter.RFEM
             if (rfConstraint.SupportConstantZ == 0)
             {
                 bhConstraint.TranslationZ = DOFType.Free;
-                bhConstraint.TranslationalStiffnessZ = 0;
             }
             else if (rfConstraint.SupportConstantZ == -1)
             {
                 bhConstraint.TranslationZ = DOFType.Fixed;
-                bhConstraint.TranslationalStiffnessZ = -1;
+
+
             }
             else
             {
-                bhConstraint.TranslationalStiffnessX = rfConstraint.SupportConstantZ;
+                bhConstraint.TranslationalStiffnessZ = rfConstraint.SupportConstantZ;
                 bhConstraint.TranslationZ = DOFType.Spring;
             }
 
@@ -103,12 +103,12 @@ namespace BH.Adapter.RFEM
             if (rfConstraint.RestraintConstantX == 0)
             {
                 bhConstraint.RotationX = DOFType.Free;
-                bhConstraint.RotationalStiffnessX = 0;
             }
             else if (rfConstraint.RestraintConstantX == -1)
             {
                 bhConstraint.RotationX = DOFType.Fixed;
-                bhConstraint.RotationalStiffnessX = -1;
+
+
             }
             else
             {
@@ -120,12 +120,12 @@ namespace BH.Adapter.RFEM
             if (rfConstraint.RestraintConstantY == 0)
             {
                 bhConstraint.RotationY = DOFType.Free;
-                bhConstraint.RotationalStiffnessY = 0;
             }
             else if (rfConstraint.RestraintConstantY == -1)
             {
                 bhConstraint.RotationY = DOFType.Fixed;
-                bhConstraint.RotationalStiffnessY = -1;
+
+
             }
             else
             {
@@ -137,12 +137,12 @@ namespace BH.Adapter.RFEM
             if (rfConstraint.RestraintConstantZ == 0)
             {
                 bhConstraint.RotationZ = DOFType.Free;
-                bhConstraint.RotationalStiffnessZ = 0;
             }
             else if (rfConstraint.RestraintConstantZ == -1)
             {
                 bhConstraint.RotationZ = DOFType.Fixed;
-                bhConstraint.RotationalStiffnessZ = -1;
+
+
             }
             else
             {

--- a/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
@@ -43,11 +43,11 @@ namespace BH.Adapter.RFEM
             rfConstraint.No = constraintId;
             rfConstraint.NodeList = nodeId.ToString();//<-- id reference to node(s) required for writing constraint to RFEM 
 
-            //Translation - RFEM unit is N/m
+
             if (constraint.TranslationX == DOFType.Free)
                 rfConstraint.SupportConstantX = 0;
             else if (constraint.TranslationX == DOFType.Fixed)
-                rfConstraint.SupportConstantX = -1;
+               rfConstraint.SupportConstantX = -1;
             else
                 rfConstraint.SupportConstantX = constraint.TranslationalStiffnessX;
 
@@ -87,7 +87,7 @@ namespace BH.Adapter.RFEM
             else
                 rfConstraint.RestraintConstantZ = constraint.RotationalStiffnessZ;
 
-         
+            new Constraint6DOF { Name = "name" };
            
 
             return rfConstraint;

--- a/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Constraint.cs
@@ -87,8 +87,7 @@ namespace BH.Adapter.RFEM
             else
                 rfConstraint.RestraintConstantZ = constraint.RotationalStiffnessZ;
 
-            new Constraint6DOF { Name = "name" };
-           
+
 
             return rfConstraint;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #13 
Closes #132 
 <!-- Add short description of what has been fixed -->
13: Push and Pull of ConstraintDOF elements has been altered so that the user is now able to push supports with either the DOFType Fixed, Free or Spring. When spring is chosen the corresponding stiffness will be set. An analog feature for the pull has been implemented. When a dimension (x, y or z) is set to be fixed the stiffens received is set to -1 while free is represented by 0. If the constraint in RFEM is a spring a double number is assigned to the corresponding parameter.

132: A push of a panel from GH into a surface in RFEM is only possible when a property has been added to the panel in GH. Previously the push node did give an error when trying to push but did not indicate why the push was not done. Now the push node is giving the user information about the missing property.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Link](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/RFEM_Toolkit-Fix%20Push_Pull%20of%20Constraint6DOF%20and%20added%20null%20check%20for%20create%20method%20in%20RFEM_Toolkit.gh?csf=1&web=1&e=6JJUgH)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Fixed Push/Pull of Constraint6DOF to and from RFEM int Grasshopper. 
- Added a Null Check for a panel in the RFEM_Toolkit.

 ### Additional comments
<!-- As required -->
