### PR TITLE
Add support for openings in panels

### DIFF
--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -61,16 +61,35 @@ namespace BH.Adapter.RFEM
                     List<string> outlineNodeList = new List<string>();
                     foreach (Edge e in panelList[i].ExternalEdges)
                     {
+                        Polyline polyline = e.Curve as Polyline;
+                        
                         //create rfem nodes, i.e. bhom points - NOTE: RFEM will remove the coincident points itself leaving jumps in node numbering ! 1,2,4,6,8,10,...
                         Line edgeAsLine = e.Curve as Line;
 
-                        rf.Node rfNode1 = new rf.Node
+                        rf.Node rfNode1 = new rf.Node();
+
+                        if (e.Curve.GetType().Name.Equals("Polyline"))
                         {
-                            No = (int)this.NextFreeId(typeof(Node)),
-                            X = edgeAsLine.Start.X,
-                            Y = edgeAsLine.Start.Y,
-                            Z = edgeAsLine.Start.Z
+
+
+                            rfNode1.No = (int)this.NextFreeId(typeof(Node));
+                            rfNode1.X = polyline.ControlPoints[0].X;
+                            rfNode1.Y = polyline.ControlPoints[0].Y;
+                            rfNode1.Z = polyline.ControlPoints[0].Z;
+
+                        }
+                        else
+                        {
+
+
+                                rfNode1.No = (int)this.NextFreeId(typeof(Node));
+                                rfNode1.X = edgeAsLine.Start.X;
+                                rfNode1.Y = edgeAsLine.Start.Y;
+                                rfNode1.Z = edgeAsLine.Start.Z;
+                            
                         };
+
+                   
                         modelData.SetNode(rfNode1);
 
                         outlineNodeList.Add(rfNode1.No.ToString());
@@ -108,23 +127,47 @@ namespace BH.Adapter.RFEM
                         rf.Opening[] rfOpenings = new rf.Opening[openingList.Count];
                         int openingId = 0;
 
+
                         for (int o = 0; o < openingList.Count; o++)
                         {
                             openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
                             List<string> openingOutlineNodeList = new List<string>();
                             
+                           
                             //Defining Nodes
                             foreach (Edge e in openingList[o].Edges)
                             {
                                 Line edgeAsLine = e.Curve as Line;
+                                Polyline polyline = e.Curve as Polyline;
 
-                                rf.Node rfNode = new rf.Node
+                                rf.Node rfNode = new rf.Node();
+                                if (e.Curve.GetType().Name.Equals("Polyline"))
                                 {
-                                    No = (int)this.NextFreeId(typeof(Node)),
-                                    X = edgeAsLine.Start.X,
-                                    Y = edgeAsLine.Start.Y,
-                                    Z = edgeAsLine.Start.Z
-                                };
+                                    
+                                    rfNode.No = (int)this.NextFreeId(typeof(Node));
+                                    rfNode.X = polyline.ControlPoints[0].X;
+                                    rfNode.Y = polyline.ControlPoints[0].Y;
+                                    rfNode.Z = polyline.ControlPoints[0].Z;
+                                }
+                                else
+                                {
+                                    
+                                    rfNode.No = (int)this.NextFreeId(typeof(Node));
+                                    rfNode.X = edgeAsLine.Start.X;
+                                    rfNode.Y = edgeAsLine.Start.Y;
+                                    rfNode.Z = edgeAsLine.Start.Z;
+                                }
+
+                             
+
+                                //rf.Node rfNode = new rf.Node
+                                //{
+                                //    No = (int)this.NextFreeId(typeof(Node)),
+                                //    X = edgeAsLine.Start.X,
+                                //    Y = edgeAsLine.Start.Y,
+                                //    Z = edgeAsLine.Start.Z
+                                //};
+
                                 modelData.SetNode(rfNode);
                                 openingOutlineNodeList.Add(rfNode.No.ToString());
                             }
@@ -143,7 +186,7 @@ namespace BH.Adapter.RFEM
 
                             rf.Opening opening = new rf.Opening()
                             {
-                                No = openingId,
+                                No = openingId+1,
                                 InSurfaceNo = rfSurfaces[i].No,
                                 BoundaryLineList = String.Join(",", openingOutline.No)
                             };

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -61,35 +61,44 @@ namespace BH.Adapter.RFEM
                     List<string> outlineNodeList = new List<string>();
                     foreach (Edge e in panelList[i].ExternalEdges)
                     {
-                        Polyline polyline = e.Curve as Polyline;
-
+                        
                         //create rfem nodes, i.e. bhom points - NOTE: RFEM will remove the coincident points itself leaving jumps in node numbering ! 1,2,4,6,8,10,...
-                        Line edgeAsLine = e.Curve as Line;
 
                         rf.Node rfNode1 = new rf.Node();
 
                         if (e.Curve.GetType().Name.Equals("Polyline"))
                         {
-                            //TODO:
-                            //Add section that enables the algo to handle polylines larege than 2 pts.
 
-                            rfNode1.No = (int)this.NextFreeId(typeof(Node));
-                            rfNode1.X = polyline.ControlPoints[0].X;
-                            rfNode1.Y = polyline.ControlPoints[0].Y;
-                            rfNode1.Z = polyline.ControlPoints[0].Z;
+                            Polyline polyline = e.Curve as Polyline;
+
+                            for (int j=0; j<polyline.ControlPoints.Count-1;j++)
+                            {
+                                rfNode1 = new rf.Node();
+
+                                rfNode1.No = (int)this.NextFreeId(typeof(Node));
+                                rfNode1.X = polyline.ControlPoints[j].X;
+                                rfNode1.Y = polyline.ControlPoints[j].Y;
+                                rfNode1.Z = polyline.ControlPoints[j].Z;
+
+                                modelData.SetNode(rfNode1);
+                                outlineNodeList.Add(rfNode1.No.ToString());
+                            }
 
                         }
                         else
                         {
-                                rfNode1.No = (int)this.NextFreeId(typeof(Node));
-                                rfNode1.X = edgeAsLine.Start.X;
-                                rfNode1.Y = edgeAsLine.Start.Y;
-                                rfNode1.Z = edgeAsLine.Start.Z;
+                            Line edgeAsLine = e.Curve as Line;
+
+                            rfNode1.No = (int)this.NextFreeId(typeof(Node));
+                            rfNode1.X = edgeAsLine.Start.X;
+                            rfNode1.Y = edgeAsLine.Start.Y;
+                            rfNode1.Z = edgeAsLine.Start.Z;
+
+                            modelData.SetNode(rfNode1);
+                            outlineNodeList.Add(rfNode1.No.ToString());
+
                         };
-
-                        modelData.SetNode(rfNode1);
-
-                        outlineNodeList.Add(rfNode1.No.ToString());
+                       
                     }
                     outlineNodeList.Add(outlineNodeList[0]);
 
@@ -133,33 +142,42 @@ namespace BH.Adapter.RFEM
                             //Defining Nodes
                             foreach (Edge e in openingList[o].Edges)
                             {
-                                Line edgeAsLine = e.Curve as Line;
-                                Polyline polyline = e.Curve as Polyline;
-
+                                
                                 rf.Node rfNode = new rf.Node();
                                 if (e.Curve.GetType().Name.Equals("Polyline"))
                                 {
-                                    //TODO:
-                                    //Add section that enables the algo to handle polylines larege than 2 pts.
+
+                                    Polyline polyline = e.Curve as Polyline;
+
+                                    for (int j = 0; j < polyline.ControlPoints.Count - 1; j++)
+                                    {
+                                        rfNode=new rf.Node();
+
+                                        rfNode.No = (int)this.NextFreeId(typeof(Node));
+                                        rfNode.X = polyline.ControlPoints[j].X;
+                                        rfNode.Y = polyline.ControlPoints[j].Y;
+                                        rfNode.Z = polyline.ControlPoints[j].Z;
 
 
-                                    rfNode.No = (int)this.NextFreeId(typeof(Node));
-                                    rfNode.X = polyline.ControlPoints[0].X;
-                                    rfNode.Y = polyline.ControlPoints[0].Y;
-                                    rfNode.Z = polyline.ControlPoints[0].Z;
+                                        modelData.SetNode(rfNode);
+                                        openingOutlineNodeList.Add(rfNode.No.ToString());
+
+                                    }
+
                                 }
                                 else
                                 {
-                                    
+                                    Line edgeAsLine = e.Curve as Line;
+
                                     rfNode.No = (int)this.NextFreeId(typeof(Node));
                                     rfNode.X = edgeAsLine.Start.X;
                                     rfNode.Y = edgeAsLine.Start.Y;
                                     rfNode.Z = edgeAsLine.Start.Z;
+
+                                    modelData.SetNode(rfNode);
+                                    openingOutlineNodeList.Add(rfNode.No.ToString());
                                 }
 
-
-                                modelData.SetNode(rfNode);
-                                openingOutlineNodeList.Add(rfNode.No.ToString());
                             }
                             openingOutlineNodeList.Add(openingOutlineNodeList[0]);
 

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -88,28 +88,33 @@ namespace BH.Adapter.RFEM
 
                     rfSurfaces[i] = panelList[i].ToRFEM(panelIdNum, new int[] { outline.No });
 
-
-                    ///Openings
-
-                    if (panelList[i].Openings.Count>0)
+                    if(rfSurfaces[i].StiffnessType == rf.SurfaceStiffnessType.StandardStiffnessType)
                     {
+                        modelData.SetSurface(rfSurfaces[i]);
+                    }
+                    else
+                    {
+                        rf.SurfaceStiffness stiffness = panelList[i].Property.ToRFEM();
+                        rfSurfaces[i].Thickness.Constant = stiffness.Thickness;
+                        rf.ISurface srf = modelData.SetSurface(rfSurfaces[i]);
+                        rf.IOrthotropicThickness ortho = srf.GetOrthotropicThickness();
+                        ortho.SetData(stiffness);
+                    }
 
-                        List<Opening> openings = panelList[i].Openings;
-                        rf.Opening[] rfOpenings = new rf.Opening[openings.Count];
+                    //Openings
+                    if (panelList[i].Openings.Count > 0)
+                    {
+                        List<Opening> openingList = panelList[i].Openings;
+                        rf.Opening[] rfOpenings = new rf.Opening[openingList.Count];
                         int openingId = 0;
 
-                        foreach (Opening o in openings)
+                        for (int o = 0; o < openingList.Count; o++)
                         {
-
-                            int count = 0;
                             openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
-
                             List<string> openingOutlineNodeList = new List<string>();
-
                             
-
                             //Defining Nodes
-                            foreach (Edge e in o.Edges)
+                            foreach (Edge e in openingList[o].Edges)
                             {
                                 Line edgeAsLine = e.Curve as Line;
 
@@ -141,44 +146,16 @@ namespace BH.Adapter.RFEM
                                 No = openingId,
                                 InSurfaceNo = rfSurfaces[i].No,
                                 BoundaryLineList = String.Join(",", openingOutline.No)
-                                
                             };
 
-                            rfOpenings[count]= opening;
+                            rfOpenings[o] = opening;
+                            rfSurfaces[i].IntegratedOpeningList = String.Join(",", new int[] { opening.No });
+
                             modelData.SetOpening(opening);
-                            rfSurfaces[i].IntegratedOpeningList = String.Join(",", new int[] {opening.No});
-
-
-                            
                         }
-                        modelData.SetSurface(rfSurfaces[i]);
-
-
-                    };
-
-
-
-
-
-                    ////
-
-
-                    if(rfSurfaces[i].StiffnessType == rf.SurfaceStiffnessType.StandardStiffnessType)
-                    {
-                        modelData.SetSurface(rfSurfaces[i]);
                     }
-                    else
-                    {
-                        rf.SurfaceStiffness stiffness = panelList[i].Property.ToRFEM();
-                        rfSurfaces[i].Thickness.Constant = stiffness.Thickness;
-                        rf.ISurface srf = modelData.SetSurface(rfSurfaces[i]);
-                        rf.IOrthotropicThickness ortho = srf.GetOrthotropicThickness();
-                        ortho.SetData(stiffness);
-                    }
-
 
                 }
-
             }
 
             return true;

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -88,6 +88,81 @@ namespace BH.Adapter.RFEM
 
                     rfSurfaces[i] = panelList[i].ToRFEM(panelIdNum, new int[] { outline.No });
 
+
+                    ///Openings
+
+                    if (panelList[i].Openings.Count>0)
+                    {
+
+                        List<Opening> openings = panelList[i].Openings;
+                        rf.Opening[] rfOpenings = new rf.Opening[openings.Count];
+                        int openingId = 0;
+
+                        foreach (Opening o in openings)
+                        {
+
+                            int count = 0;
+                            openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
+
+                            List<string> openingOutlineNodeList = new List<string>();
+
+                            
+
+                            //Defining Nodes
+                            foreach (Edge e in o.Edges)
+                            {
+                                Line edgeAsLine = e.Curve as Line;
+
+                                rf.Node rfNode = new rf.Node
+                                {
+                                    No = (int)this.NextFreeId(typeof(Node)),
+                                    X = edgeAsLine.Start.X,
+                                    Y = edgeAsLine.Start.Y,
+                                    Z = edgeAsLine.Start.Z
+                                };
+                                modelData.SetNode(rfNode);
+                                openingOutlineNodeList.Add(rfNode.No.ToString());
+                            }
+                            openingOutlineNodeList.Add(openingOutlineNodeList[0]);
+
+                            lastLineId = modelData.GetLastObjectNo(rf.ModelObjectType.LineObject);
+
+                            //Defining Lines
+                            rf.Line openingOutline = new rf.Line()
+                            {
+                                No = lastLineId + 1,
+                                Type = rf.LineType.PolylineType,
+                                NodeList = String.Join(",", openingOutlineNodeList)
+                            };
+                            modelData.SetLine(openingOutline);
+
+                            rf.Opening opening = new rf.Opening()
+                            {
+                                No = openingId,
+                                InSurfaceNo = rfSurfaces[i].No,
+                                BoundaryLineList = String.Join(",", openingOutline.No)
+                                
+                            };
+
+                            rfOpenings[count]= opening;
+                            modelData.SetOpening(opening);
+                            rfSurfaces[i].IntegratedOpeningList = String.Join(",", new int[] {opening.No});
+
+
+                            
+                        }
+                        modelData.SetSurface(rfSurfaces[i]);
+
+
+                    };
+
+
+
+
+
+                    ////
+
+
                     if(rfSurfaces[i].StiffnessType == rf.SurfaceStiffnessType.StandardStiffnessType)
                     {
                         modelData.SetSurface(rfSurfaces[i]);

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -70,6 +70,9 @@ namespace BH.Adapter.RFEM
 
                         if (e.Curve.GetType().Name.Equals("Polyline"))
                         {
+                            //TODO:
+                            //Add section that enables the algo to handle polylines larege than 2 pts.
+
                             rfNode1.No = (int)this.NextFreeId(typeof(Node));
                             rfNode1.X = polyline.ControlPoints[0].X;
                             rfNode1.Y = polyline.ControlPoints[0].Y;
@@ -136,7 +139,10 @@ namespace BH.Adapter.RFEM
                                 rf.Node rfNode = new rf.Node();
                                 if (e.Curve.GetType().Name.Equals("Polyline"))
                                 {
-                                    
+                                    //TODO:
+                                    //Add section that enables the algo to handle polylines larege than 2 pts.
+
+
                                     rfNode.No = (int)this.NextFreeId(typeof(Node));
                                     rfNode.X = polyline.ControlPoints[0].X;
                                     rfNode.Y = polyline.ControlPoints[0].Y;

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.RFEM
                     //create outline
                     List<string> outlineNodeList = new List<string>();
                    
-                    outlineNodeList=generateOutlineNodeList(panelList[i].ExternalEdges);
+                    outlineNodeList=GenerateOutlineNodeList(panelList[i].ExternalEdges);
 
                     rf.Line outline = new rf.Line()
                     {
@@ -97,7 +97,7 @@ namespace BH.Adapter.RFEM
                             openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
                             List<string> openingOutlineNodeList = new List<string>();
 
-                            openingOutlineNodeList=generateOutlineNodeList(openingList[o].Edges);
+                            openingOutlineNodeList=GenerateOutlineNodeList(openingList[o].Edges);
 
                             lastLineId = modelData.GetLastObjectNo(rf.ModelObjectType.LineObject);
 
@@ -132,9 +132,9 @@ namespace BH.Adapter.RFEM
         }
 
 
-        public List<String> generateOutlineNodeList(List<Edge> edgeList)
+        public List<string> GenerateOutlineNodeList(List<Edge> edgeList)
         {
-            List<String> outlineNodeList = new List<String>();
+            List<string> outlineNodeList = new List<string>();
 
             //Defining Nodes
             foreach (Edge e in edgeList)

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -54,53 +54,12 @@ namespace BH.Adapter.RFEM
                     //get ids outside of BHoM process - might need to be changed
                     int lastLineId = modelData.GetLastObjectNo(rf.ModelObjectType.LineObject);
 
-
                     int[] boundaryIdArr = new int[panelList[i].ExternalEdges.Count()];
 
                     //create outline
                     List<string> outlineNodeList = new List<string>();
-                    foreach (Edge e in panelList[i].ExternalEdges)
-                    {
-                        
-                        //create rfem nodes, i.e. bhom points - NOTE: RFEM will remove the coincident points itself leaving jumps in node numbering ! 1,2,4,6,8,10,...
-
-                        rf.Node rfNode1 = new rf.Node();
-
-                        if (e.Curve.GetType().Name.Equals("Polyline"))
-                        {
-
-                            Polyline polyline = e.Curve as Polyline;
-
-                            for (int j=0; j<polyline.ControlPoints.Count-1;j++)
-                            {
-                                rfNode1 = new rf.Node();
-
-                                rfNode1.No = (int)this.NextFreeId(typeof(Node));
-                                rfNode1.X = polyline.ControlPoints[j].X;
-                                rfNode1.Y = polyline.ControlPoints[j].Y;
-                                rfNode1.Z = polyline.ControlPoints[j].Z;
-
-                                modelData.SetNode(rfNode1);
-                                outlineNodeList.Add(rfNode1.No.ToString());
-                            }
-
-                        }
-                        else
-                        {
-                            Line edgeAsLine = e.Curve as Line;
-
-                            rfNode1.No = (int)this.NextFreeId(typeof(Node));
-                            rfNode1.X = edgeAsLine.Start.X;
-                            rfNode1.Y = edgeAsLine.Start.Y;
-                            rfNode1.Z = edgeAsLine.Start.Z;
-
-                            modelData.SetNode(rfNode1);
-                            outlineNodeList.Add(rfNode1.No.ToString());
-
-                        };
-                       
-                    }
-                    outlineNodeList.Add(outlineNodeList[0]);
+                   
+                    outlineNodeList=generateOutlineNodeList(panelList[i].ExternalEdges);
 
                     rf.Line outline = new rf.Line()
                     {
@@ -137,46 +96,8 @@ namespace BH.Adapter.RFEM
                         {
                             openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
                             List<string> openingOutlineNodeList = new List<string>();
-                            
-                            //Defining Nodes
-                            foreach (Edge e in openingList[o].Edges)
-                            {
-                                
-                                rf.Node rfNode = new rf.Node();
-                                if (e.Curve.GetType().Name.Equals("Polyline"))
-                                {
 
-                                    Polyline polyline = e.Curve as Polyline;
-
-                                    for (int j = 0; j < polyline.ControlPoints.Count - 1; j++)
-                                    {
-                                        rfNode=new rf.Node();
-
-                                        rfNode.No = (int)this.NextFreeId(typeof(Node));
-                                        rfNode.X = polyline.ControlPoints[j].X;
-                                        rfNode.Y = polyline.ControlPoints[j].Y;
-                                        rfNode.Z = polyline.ControlPoints[j].Z;
-
-                                        modelData.SetNode(rfNode);
-                                        openingOutlineNodeList.Add(rfNode.No.ToString());
-
-                                    }
-                                }
-                                else
-                                {
-                                    Line edgeAsLine = e.Curve as Line;
-
-                                    rfNode.No = (int)this.NextFreeId(typeof(Node));
-                                    rfNode.X = edgeAsLine.Start.X;
-                                    rfNode.Y = edgeAsLine.Start.Y;
-                                    rfNode.Z = edgeAsLine.Start.Z;
-
-                                    modelData.SetNode(rfNode);
-                                    openingOutlineNodeList.Add(rfNode.No.ToString());
-                                }
-
-                            }
-                            openingOutlineNodeList.Add(openingOutlineNodeList[0]);
+                            openingOutlineNodeList=generateOutlineNodeList(openingList[o].Edges);
 
                             lastLineId = modelData.GetLastObjectNo(rf.ModelObjectType.LineObject);
 
@@ -208,6 +129,54 @@ namespace BH.Adapter.RFEM
             }
 
             return true;
+        }
+
+
+        public List<String> generateOutlineNodeList(List<Edge> edgeList)
+        {
+            List<String> outlineNodeList = new List<String>();
+
+            //Defining Nodes
+            foreach (Edge e in edgeList)
+            {
+             
+                rf.Node rfNode = new rf.Node();
+                
+                if (e.Curve is Polyline)
+                {
+
+                    Polyline polyline = e.Curve as Polyline;
+
+                    for (int j = 0; j < polyline.ControlPoints.Count - 1; j++)
+                    {
+                        rfNode = new rf.Node();
+
+                        rfNode.No = (int)this.NextFreeId(typeof(Node));
+                        rfNode.X = polyline.ControlPoints[j].X;
+                        rfNode.Y = polyline.ControlPoints[j].Y;
+                        rfNode.Z = polyline.ControlPoints[j].Z;
+
+                        modelData.SetNode(rfNode);
+                        outlineNodeList.Add(rfNode.No.ToString());
+                    }
+                }
+                else
+                {
+                    Line edgeAsLine = e.Curve as Line;
+
+                    rfNode.No = (int)this.NextFreeId(typeof(Node));
+                    rfNode.X = edgeAsLine.Start.X;
+                    rfNode.Y = edgeAsLine.Start.Y;
+                    rfNode.Z = edgeAsLine.Start.Z;
+
+                    modelData.SetNode(rfNode);
+                    outlineNodeList.Add(rfNode.No.ToString());
+                }
+
+            }
+            outlineNodeList.Add(outlineNodeList[0]);
+
+            return outlineNodeList;
         }
 
     }

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -110,7 +110,6 @@ namespace BH.Adapter.RFEM
                     };
                     modelData.SetLine(outline);
 
-
                     rfSurfaces[i] = panelList[i].ToRFEM(panelIdNum, new int[] { outline.No });
 
                     if(rfSurfaces[i].StiffnessType == rf.SurfaceStiffnessType.StandardStiffnessType)
@@ -158,12 +157,10 @@ namespace BH.Adapter.RFEM
                                         rfNode.Y = polyline.ControlPoints[j].Y;
                                         rfNode.Z = polyline.ControlPoints[j].Z;
 
-
                                         modelData.SetNode(rfNode);
                                         openingOutlineNodeList.Add(rfNode.No.ToString());
 
                                     }
-
                                 }
                                 else
                                 {

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -62,7 +62,7 @@ namespace BH.Adapter.RFEM
                     foreach (Edge e in panelList[i].ExternalEdges)
                     {
                         Polyline polyline = e.Curve as Polyline;
-                        
+
                         //create rfem nodes, i.e. bhom points - NOTE: RFEM will remove the coincident points itself leaving jumps in node numbering ! 1,2,4,6,8,10,...
                         Line edgeAsLine = e.Curve as Line;
 
@@ -70,8 +70,6 @@ namespace BH.Adapter.RFEM
 
                         if (e.Curve.GetType().Name.Equals("Polyline"))
                         {
-
-
                             rfNode1.No = (int)this.NextFreeId(typeof(Node));
                             rfNode1.X = polyline.ControlPoints[0].X;
                             rfNode1.Y = polyline.ControlPoints[0].Y;
@@ -80,16 +78,12 @@ namespace BH.Adapter.RFEM
                         }
                         else
                         {
-
-
                                 rfNode1.No = (int)this.NextFreeId(typeof(Node));
                                 rfNode1.X = edgeAsLine.Start.X;
                                 rfNode1.Y = edgeAsLine.Start.Y;
                                 rfNode1.Z = edgeAsLine.Start.Z;
-                            
                         };
 
-                   
                         modelData.SetNode(rfNode1);
 
                         outlineNodeList.Add(rfNode1.No.ToString());
@@ -133,7 +127,6 @@ namespace BH.Adapter.RFEM
                             openingId = modelData.GetLastObjectNo(rf.ModelObjectType.OpeningObject);
                             List<string> openingOutlineNodeList = new List<string>();
                             
-                           
                             //Defining Nodes
                             foreach (Edge e in openingList[o].Edges)
                             {
@@ -158,15 +151,6 @@ namespace BH.Adapter.RFEM
                                     rfNode.Z = edgeAsLine.Start.Z;
                                 }
 
-                             
-
-                                //rf.Node rfNode = new rf.Node
-                                //{
-                                //    No = (int)this.NextFreeId(typeof(Node)),
-                                //    X = edgeAsLine.Start.X,
-                                //    Y = edgeAsLine.Start.Y,
-                                //    Z = edgeAsLine.Start.Z
-                                //};
 
                                 modelData.SetNode(rfNode);
                                 openingOutlineNodeList.Add(rfNode.No.ToString());
@@ -184,6 +168,7 @@ namespace BH.Adapter.RFEM
                             };
                             modelData.SetLine(openingOutline);
 
+                            //Defining Openings
                             rf.Opening opening = new rf.Opening()
                             {
                                 No = openingId+1,

--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -78,8 +78,8 @@ namespace BH.Adapter.RFEM
                     
                     List<Opening> openings = new List<Opening>();
 
-                    //if opening exists in panel
-                    if (!(surface.BoundaryLineList.Length == 0))
+                    //if opening exists in panel     
+                    if (!(surface.IntegratedOpeningList.Length == 0))
                     {
                         List<int> openingIDList = GetIdListFromString(surface.IntegratedOpeningList);
 
@@ -119,7 +119,7 @@ namespace BH.Adapter.RFEM
                     List<Opening> openings = new List<Opening>();
 
                     //if opening exists in panel
-                    if (!(surface.BoundaryLineList.Length == 0))
+                    if (!(surface.IntegratedOpeningList.Length == 0))
                     {
                         List<int> openingIDList = GetIdListFromString(surface.IntegratedOpeningList);
 
@@ -177,6 +177,7 @@ namespace BH.Adapter.RFEM
             if(idsAsString.Contains('-') & idsAsString.Contains(','))
             {
                 foreach(string part in idsAsString.Split(','))
+                foreach (string part in idsAsString.Split(','))
                 {
                     if (!part.Contains('-'))
                     {
@@ -204,6 +205,7 @@ namespace BH.Adapter.RFEM
             }
 
             return idList;
+
         }
 
         private List<ICurve> GetEdgesAsCurveFromOpenings(rf.Opening openings)

--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -78,8 +78,7 @@ namespace BH.Adapter.RFEM
                     
                     List<Opening> openings = new List<Opening>();
 
-
-                    //if opening panel exists
+                    //if opening exists in panel
                     if (!(surface.BoundaryLineList.Length == 0))
                     {
                         List<int> openingIDList = GetIdListFromString(surface.IntegratedOpeningList);
@@ -88,20 +87,10 @@ namespace BH.Adapter.RFEM
                         {
                            
                             rf.Opening rfOpening = modelData.GetOpening(i, rf.ItemAt.AtNo).GetData();
-                            List<Edge> edges = GetEdgesFromOpenings(rfOpening);
-                            List<ICurve> iCurveList = new List<ICurve>(); 
-
-                            foreach (Edge e in edges)
-                            {
-                                iCurveList.Add(e.Curve);
-                            }
-                    
-                            Opening opening = Engine.Structure.Create.Opening(iCurveList);
-       
+                            List<ICurve> edges = GetEdgesAsCurveFromOpenings(rfOpening);
+                            Opening opening = Engine.Structure.Create.Opening(edges);
                             openings.Add(opening);
                         }
-
-
                     }
 
                     Panel panel = Engine.Structure.Create.Panel(edgeList, openings, surfaceProperty);
@@ -127,31 +116,21 @@ namespace BH.Adapter.RFEM
                     rf.SurfaceStiffness stiffness = ortho.GetData();
 
                     surfaceProperty = stiffness.FromRFEM(material);
-                    List<Opening> openings = null;
+                    List<Opening> openings = new List<Opening>();
 
-
-
-
-
-                    //if opening panel exists
+                    //if opening exists in panel
                     if (!(surface.BoundaryLineList.Length == 0))
                     {
-                        List<int> openingIDList = GetIdListFromString(surface.BoundaryLineList);
+                        List<int> openingIDList = GetIdListFromString(surface.IntegratedOpeningList);
 
                         foreach (int i in openingIDList)
                         {
-                            Opening opening = new Opening();
+
                             rf.Opening rfOpening = modelData.GetOpening(i, rf.ItemAt.AtNo).GetData();
-
-                            opening.Edges = GetEdgesFromOpenings(rfOpening);
-                            //panel.Openings.Add(opening);
-                            //openings.Add(opening);
-
-
-                            openings.Add(Engine.Structure.Create.Opening((oM.Geometry.ICurve)GetEdgesFromOpenings(rfOpening)));
+                            List<ICurve> edges = GetEdgesAsCurveFromOpenings(rfOpening);
+                            Opening opening = Engine.Structure.Create.Opening(edges);
+                            openings.Add(opening);
                         }
-
-
                     }
 
                     Panel panel = Engine.Structure.Create.Panel(edgeList, openings, surfaceProperty);
@@ -227,13 +206,12 @@ namespace BH.Adapter.RFEM
             return idList;
         }
 
-        private List<Edge> GetEdgesFromOpenings(rf.Opening openings)
+        private List<ICurve> GetEdgesAsCurveFromOpenings(rf.Opening openings)
         {
-            List<Edge> edges = new List<Edge>();
+            
+            List<ICurve> edgesAsCurve = new List<ICurve>();
             string boundaryString = modelData.GetOpening(openings.No, rf.ItemAt.AtNo).GetData().BoundaryLineList;
-
             List<int> boundaryLineIds = GetIdListFromString(boundaryString);
-
 
             foreach (int edgeId in boundaryLineIds)
             {
@@ -246,11 +224,12 @@ namespace BH.Adapter.RFEM
                     rf.Node rfNode = modelData.GetNode(ptId, rf.ItemAt.AtNo).GetData();
                     ptsInEdge.Add(new oM.Geometry.Point() { X = rfNode.X, Y = rfNode.Y, Z = rfNode.Z });
                 }
-                edges.Add(new Edge { Curve = Engine.Geometry.Create.Polyline(ptsInEdge) });
+
+                edgesAsCurve.Add(Engine.Geometry.Create.Polyline(ptsInEdge));
             }
 
 
-            return edges;
+            return edgesAsCurve;
         }
 
     }

--- a/RFEM_Adapter/CRUD/Read/Panel.cs
+++ b/RFEM_Adapter/CRUD/Read/Panel.cs
@@ -174,9 +174,8 @@ namespace BH.Adapter.RFEM
             //NOTE: the below only works if RFEM does not use a mix of ',' and '-' delimiters !!
             List<int> idList = new List<int>();
 
-            if(idsAsString.Contains('-') & idsAsString.Contains(','))
+            if (idsAsString.Contains('-') & idsAsString.Contains(','))
             {
-                foreach(string part in idsAsString.Split(','))
                 foreach (string part in idsAsString.Split(','))
                 {
                     if (!part.Contains('-'))


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #57

 <!-- Add short description of what has been fixed -->
In the previous version the pull and push of panel did not include openings inside of those. The pulled/pushed panel was only able to transfer panel without openings. Additionally, the push was only able to include a single panel. 
In the current version it should be possible to push and pull any number or panels with an arbitrary number of openings between RFEM and GH.



 ### Test files
<!-- Link to test files to validate the proposed changes -->
[File](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRFEM%5FToolkit%2FRFEM%5FToolkit%5Fread%20and%20write%20panels%20with%20openings%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRFEM%5FToolkit)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
-Push/Pull of openings included in panels in RFEM_Toolkit.
-Push/Pull of arbitrary number of panels.