### PR TITLE
Fixing Incorrect Material Push/Pull 

### DIFF
--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -46,15 +46,21 @@ namespace BH.Adapter.RFEM
                 List<IMaterialFragment> matList = materialFragments.ToList();
                 rf.Material[] rfMaterials = new rf.Material[matList.Count()];
 
-                for(int i=0;i< matList.Count();i++)
+                for (int i = 0; i < matList.Count(); i++)
                 {
                     idNum = GetAdapterId<int>(matList[i]);// NextId(matList[i].GetType()));
                     rfMaterials[i] = matList[i].ToRFEM(idNum);
 
+
+                    List<rf.Material> alreadyExistingMaterialsOFEqualType = modelData.GetMaterials().ToList().FindAll(m => m.Description.Equals(rfMaterials[i].Description));
+
+
+                    if (alreadyExistingMaterialsOFEqualType.Count==0) {
+                        modelData.SetMaterial(rfMaterials[i]);
+                    }
+                   
+                       
                     
-                    modelData.SetMaterial(rfMaterials[i]);
-                   var x= modelData.GetMaterials().ToList().Find(m=>m.No.Equals(rfMaterials[i].No));
-                    x.TextID = "Random Id";
                    
                 }
 

--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -53,11 +53,19 @@ namespace BH.Adapter.RFEM
 
 
                     List<rf.Material> alreadyExistingMaterialsOFEqualType = modelData.GetMaterials().ToList().FindAll(m => m.Description.Equals(rfMaterials[i].Description));
-
-
-                    if (alreadyExistingMaterialsOFEqualType.Count==0) {
+                   
+                    //WIP AM
+                    bool materialAlreadyInDict = m_materialDict.Any(m => (m.Value.Name.Equals(" "+matList[i].Name))||(m.Value.Name.Equals( matList[i].Name)));
+                    if (!materialAlreadyInDict)
+                    {
+                        m_materialDict.Add(m_materialDict.Count+1, matList[i]);
                         modelData.SetMaterial(rfMaterials[i]);
                     }
+
+
+                    //if (alreadyExistingMaterialsOFEqualType.Count==0) {
+                    //    modelData.SetMaterial(rfMaterials[i]);
+                    //}
                    
                        
                     

--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -51,7 +51,11 @@ namespace BH.Adapter.RFEM
                     idNum = GetAdapterId<int>(matList[i]);// NextId(matList[i].GetType()));
                     rfMaterials[i] = matList[i].ToRFEM(idNum);
 
+                    
                     modelData.SetMaterial(rfMaterials[i]);
+                   var x= modelData.GetMaterials().ToList().Find(m=>m.No.Equals(rfMaterials[i].No));
+                    x.TextID = "Random Id";
+                   
                 }
 
                 //modelData.SetMaterials(rfMaterials);

--- a/RFEM_Adapter/CRUD/Create/Material.cs
+++ b/RFEM_Adapter/CRUD/Create/Material.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.RFEM
 
         private bool CreateCollection(IEnumerable<IMaterialFragment> materialFragments)
         {
-            if(materialFragments.Count()>0)
+            if (materialFragments.Count() > 0)
             {
                 int idNum = 0;
                 List<IMaterialFragment> matList = materialFragments.ToList();
@@ -51,28 +51,17 @@ namespace BH.Adapter.RFEM
                     idNum = GetAdapterId<int>(matList[i]);// NextId(matList[i].GetType()));
                     rfMaterials[i] = matList[i].ToRFEM(idNum);
 
-
                     List<rf.Material> alreadyExistingMaterialsOFEqualType = modelData.GetMaterials().ToList().FindAll(m => m.Description.Equals(rfMaterials[i].Description));
-                   
-                    //WIP AM
-                    bool materialAlreadyInDict = m_materialDict.Any(m => (m.Value.Name.Equals(" "+matList[i].Name))||(m.Value.Name.Equals( matList[i].Name)));
+
+                    bool materialAlreadyInDict = m_materialDict.Any(m => (m.Value.Name.Equals(" " + matList[i].Name)) || (m.Value.Name.Equals(matList[i].Name)));
                     if (!materialAlreadyInDict)
                     {
-                        m_materialDict.Add(m_materialDict.Count+1, matList[i]);
+                        m_materialDict.Add(m_materialDict.Count + 1, matList[i]);
                         modelData.SetMaterial(rfMaterials[i]);
                     }
 
-
-                    //if (alreadyExistingMaterialsOFEqualType.Count==0) {
-                    //    modelData.SetMaterial(rfMaterials[i]);
-                    //}
-                   
-                       
-                    
-                   
                 }
 
-                //modelData.SetMaterials(rfMaterials);
             }
 
             return true;

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -64,7 +64,8 @@ namespace BH.Adapter.RFEM
                     List<rf.Line> outlineNodeList = GenerateOutlineLines(panelList[i].ExternalEdges);
                     int[] numberArray = outlineNodeList.Select(line => line.No).ToArray();
                     rfSurfaces[i] = panelList[i].ToRFEM(panelIdNum, numberArray);
-                    rfSurfaces[i].MaterialNo=modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(panelList[i].Property.Material.Name)).No;
+                    //rfSurfaces[i].MaterialNo=modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(panelList[i].Property.Material.Name)).No;
+                    rfSurfaces[i].MaterialNo = modelData.GetMaterials().ToList().Find(m => m.Description.Split(':')[1].Equals(" " + panelList[i].Property.Material.Name)).No;
 
 
 

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -1,7 +1,6 @@
-
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/RFEM_Adapter/CRUD/Create/Panel.cs
+++ b/RFEM_Adapter/CRUD/Create/Panel.cs
@@ -64,6 +64,7 @@ namespace BH.Adapter.RFEM
                     List<rf.Line> outlineNodeList = GenerateOutlineLines(panelList[i].ExternalEdges);
                     int[] numberArray = outlineNodeList.Select(line => line.No).ToArray();
                     rfSurfaces[i] = panelList[i].ToRFEM(panelIdNum, numberArray);
+                    rfSurfaces[i].MaterialNo=modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(panelList[i].Property.Material.Name)).No;
 
 
 

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -50,7 +50,6 @@ namespace BH.Adapter.RFEM
 
                 for (int i = 0; i < secList.Count(); i++)
                 {
-
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
                    // matNumId = GetAdapterId<int>(secList[i]);
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
@@ -62,7 +61,6 @@ namespace BH.Adapter.RFEM
                         rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }
-
 
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                     //modelData.SetCrossSection(rfCrossSections[i]);

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -56,7 +56,8 @@ namespace BH.Adapter.RFEM
 
                     if (!sectionAlredyInDict)
                     {
-                        m_sectionDict.Add(m_sectionDict.Keys.Max() + 1, secList[i]);
+                        int maxKey = m_sectionDict.Keys.Count > 0 ? m_sectionDict.Keys.Max():0;
+                        m_sectionDict.Add(maxKey + 1, secList[i]);
                         rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -51,22 +51,18 @@ namespace BH.Adapter.RFEM
                 for (int i = 0; i < secList.Count(); i++)
                 {
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
-                   // matNumId = GetAdapterId<int>(secList[i]);
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
                     bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
 
                     if (!sectionAlredyInDict)
                     {
-                        m_sectionDict.Add(m_sectionDict.Count+1, secList[i]);
+                        m_sectionDict.Add(m_sectionDict.Keys.Max() + 1, secList[i]);
                         rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }
 
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
-                    //modelData.SetCrossSection(rfCrossSections[i]);
                 }
-
-                //modelData.SetCrossSections(rfCrossSections);
             }
 
             return true;

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -52,7 +52,9 @@ namespace BH.Adapter.RFEM
                 {
 
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
-                    matNumId = GetAdapterId<int>(secList[i]);
+                   // matNumId = GetAdapterId<int>(secList[i]);
+                    matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
+
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                     modelData.SetCrossSection(rfCrossSections[i]);
                 }

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -54,9 +54,18 @@ namespace BH.Adapter.RFEM
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
                    // matNumId = GetAdapterId<int>(secList[i]);
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
+                    bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
+
+                    if (!sectionAlredyInDict)
+                    {
+                        m_sectionDict.Add(m_sectionDict.Count+1, secList[i]);
+                        rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
+                        modelData.SetCrossSection(rfCrossSections[i]); 
+                    }
+
 
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
-                    modelData.SetCrossSection(rfCrossSections[i]);
+                    //modelData.SetCrossSection(rfCrossSections[i]);
                 }
 
                 //modelData.SetCrossSections(rfCrossSections);

--- a/RFEM_Adapter/CRUD/Read/Material.cs
+++ b/RFEM_Adapter/CRUD/Read/Material.cs
@@ -42,6 +42,7 @@ namespace BH.Adapter.RFEM
 
         private List<IMaterialFragment> ReadMaterials(List<string> ids = null)
         {
+            m_materialDict.Clear();
             List<IMaterialFragment> materialList = new List<IMaterialFragment>();
 
             if (ids == null)

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -55,7 +55,24 @@ namespace BH.Adapter.RFEM
             {
                 foreach (rf.CrossSection rfSection in modelData.GetCrossSections())
                 {
-                    rf.Material rfMaterial = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
+
+                    int rfSectMaterialNumbe;
+
+                    if (rfSection.MaterialNo==0)
+                    {
+                        Engine.Base.Compute.RecordWarning("Material number "+rfSection.No+" had no in RFEM Material assigned to it. Insted Material number 1 had been assigned to the Cross Section");
+                        rfSectMaterialNumbe = 1;
+
+                    }
+                    else
+                    {
+                        rfSectMaterialNumbe= rfSection.MaterialNo;
+                    }
+
+                    
+                    //rf.Material rfMaterial = modelData.GetMaterial(rfSection.MaterialNo, rf.ItemAt.AtNo).GetData();
+                    rf.Material rfMaterial = modelData.GetMaterial(rfSectMaterialNumbe, rf.ItemAt.AtNo).GetData();
+
                     rf.ICrossSection rfISection = modelData.GetCrossSection(rfSection.No, rf.ItemAt.AtNo);
                     ISectionProperty section = rfISection.FromRFEM(rfMaterial);
 

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -46,6 +46,7 @@ namespace BH.Adapter.RFEM
 
         private List<ISectionProperty> ReadSectionProperties(List<string> ids = null)
         {
+            m_sectionDict.Clear();
             List<ISectionProperty> sectionPropList = new List<ISectionProperty>();
 
             //ReadSectionFromRFEMLibrary("IPE 200");
@@ -63,6 +64,7 @@ namespace BH.Adapter.RFEM
                     int sectionId = rfSection.No;
                     if(!m_sectionDict.ContainsKey(sectionId))
                     {
+                        section.Name = rfISection.GetData().Comment;
                         m_sectionDict.Add(sectionId, section);
                     }
                 }

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -62,7 +62,7 @@ namespace BH.Adapter.RFEM
                     sectionPropList.Add(section);
 
                     int sectionId = rfSection.No;
-                    if(!m_sectionDict.ContainsKey(sectionId))
+                    if (!m_sectionDict.ContainsKey(sectionId))
                     {
                         section.Name = rfISection.GetData().Comment;
                         m_sectionDict.Add(sectionId, section);

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -50,6 +50,7 @@ namespace BH.Adapter.RFEM
             MaterialType matType = material.GetMaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
             string matName = Engine.Adapters.RFEM.Query.GetMaterialName(material);
 
+
             switch (matType)
             {
                 case MaterialType.Aluminium:
@@ -59,7 +60,19 @@ namespace BH.Adapter.RFEM
                     bhMaterial = Engine.Structure.Create.Steel(matName);
                     break;
                 case MaterialType.Concrete:
-                    bhMaterial = Engine.Structure.Create.Concrete(matName);
+                   // double[] matStrenth=getMaterialStrength(material);
+
+                    double elasticiy = material.ElasticityModulus;
+                    double poisson = material.PoissonRatio;
+                    double thermalEx = material.ThermalExpansion;
+                    double desity = material.SpecificWeight;
+                    double damping = 0;
+                    double cubeStrenght = 0;
+                    double cylinderStrength = 0;
+
+                    //bhMaterial = Engine.Structure.Create.Concrete(matName);
+                    bhMaterial = Engine.Structure.Create.Concrete(matName, elasticiy, poisson, thermalEx, desity, damping, cubeStrenght, cylinderStrength);
+
                     break;
                 case MaterialType.Timber://TODO: as this uses vector over double assumption is the the below turns Timber into an incorrect Isotropic material !!!
                     BH.oM.Geometry.Vector young = new oM.Geometry.Vector() { X = material.ElasticityModulus, Y = material.ElasticityModulus, Z = material.ElasticityModulus };
@@ -76,13 +89,53 @@ namespace BH.Adapter.RFEM
                 default:
                     break;
             }
-           
-         
-            bhMaterial.Name = material.Comment;
+
+
+            //bhMaterial.Name = material.Comment;
+            bhMaterial.Name = matName;
 
             bhMaterial.SetAdapterId(typeof(RFEMId), material.No);
             return bhMaterial;
         }
+
+        //private static double[] getMaterialStrength(rf.Material material)
+        //{
+        //    string[] strengthArray=new string[] {"0","0"};
+
+        //    if (material.TextID.Equals(""))
+        //    {
+
+                
+                
+        //        //  string[] materialStringArr = material.Description.Split(':');
+        //        //  string materialGradeString = "";
+                
+        //        //    switch (materialStringArr[0])
+        //        //    {
+        //        //    case "CONCRETE":
+        //        //        materialGradeString=materialStringArr[1].Substring(1);
+        //        //        strengthArray = materialGradeString.Split('/');
+        //        //        break;
+        //        //    case "STEEL":
+        //        //        break;
+        //        //    case "TIMBER":
+        //        //        break;
+        //        //    case "ALUMINIUM":
+        //        //        break; 
+        //        //    default:
+        //        //        break;
+
+
+        //        //}
+
+
+
+                
+
+        //    }
+
+        //    return new double[] { System.Convert.ToDouble(strengthArray[0])*1e9, System.Convert.ToDouble(strengthArray[1])*1e9};
+        //}
 
     }
 }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM
             IMaterialFragment bhMaterial = null;
 
             string[] stringArr = material.TextID.Split('@');
-            MaterialType matType = material.MaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
+            MaterialType matType = material.DetermineMaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
             //string matName = Engine.Adapters.RFEM.Query.GetMaterialName(material);
             string matName = material.TextID == "" ? material.Description.Split(':')[1] : material.Description;
             String[] matParaArray = material.Comment.Split('|');
@@ -96,9 +96,59 @@ namespace BH.Adapter.RFEM
             return bhMaterial;
         }
 
-        
+        private static MaterialType DetermineMaterialType(this rf.Material rfMaterial)
+        {
+       
 
+            string materialString = "";
+            string[] materialStringArr;
+
+            if (rfMaterial.Equals(null))
+            {
+                Engine.Base.Compute.RecordWarning("Material was Null and has been set to Steel");
+                return oM.Structure.MaterialFragments.MaterialType.Steel; ; //A suitable return - you could `return null;` here instead if needed
+            }
+            else
+            {
+
+                materialStringArr = rfMaterial.TextID.Split('@');
+                materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] : materialStringArr[1].Split('|')[1];
+            }
+
+
+            switch (materialString)
+            {
+
+                case "TypeID|STEEL":
+                case "STEEL":
+                    return oM.Structure.MaterialFragments.MaterialType.Steel;
+                case "ALUMINIUM":
+                    return oM.Structure.MaterialFragments.MaterialType.Aluminium;
+                case "CONCRETE":
+                    return oM.Structure.MaterialFragments.MaterialType.Concrete;
+                case "TIMBER":
+                case "CONIFEROUS":
+                    return oM.Structure.MaterialFragments.MaterialType.Timber;
+                case "CABLE":
+                    return oM.Structure.MaterialFragments.MaterialType.Cable;
+                case "GLASS":
+                    return oM.Structure.MaterialFragments.MaterialType.Glass;
+                case "TREBAR":
+                    return oM.Structure.MaterialFragments.MaterialType.Rebar;
+                case "TENDON":
+                    return oM.Structure.MaterialFragments.MaterialType.Tendon;
+                default:
+                    Engine.Base.Compute.RecordWarning("Don't know how to make: " + materialString[1]);
+                    return oM.Structure.MaterialFragments.MaterialType.Undefined;
+            }
+
+        }
+
+
+        /***************************************************/
     }
+
 }
+
 
 

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -95,67 +95,7 @@ namespace BH.Adapter.RFEM
             return bhMaterial;
         }
 
-        //private static double[] getMaterialStrength(rf.Material material)
-        //{
-        //    string[] strengthArray = new string[] { "0", "0" };
-
-        //    //Non RFEM Libary Material
-        //    if (material.TextID.Equals(""))
-        //    {
-
-        //        string[] materialStringArr = material.Description.Split(':');
-        //        string materialGradeString = "";
-
-        //        switch (materialStringArr[0])
-        //        {
-        //            case "CONCRETE":
-        //                materialGradeString = materialStringArr[1].Substring(2);
-        //                strengthArray = materialGradeString.Split('/');
-        //                break;
-        //            case "STEEL":
-        //                //Upper boundary for Reading the yield stress from name. Check for Rebar
-        //                int upperBoundary = materialStringArr[1].Substring(0, 2) == " B" ? materialStringArr[1].Length - 3 : materialStringArr[1].Length - 2;
-        //                strengthArray[0] = materialStringArr[1].Substring(2, upperBoundary).Split(null)[0];
-        //                break;
-        //            case "TIMBER":
-        //                break;
-        //            case "ALUMINIUM":
-        //                break;
-        //            default:
-        //                break;
-
-        //        }
-
-        //    }// RFEM Libary Material
-        //    else
-        //    {
-        //        string[] materialStringArr = material.TextID.Split('@');
-        //        string materialGradeString = "";
-
-        //        switch (materialStringArr[1])
-        //        {
-        //            case "TypeID|CONCRETE":
-        //                materialGradeString = materialStringArr[0].Split(null)[1];
-        //                strengthArray = materialGradeString.Substring(1).Split('/');
-        //                break;
-        //            case "TypeID|STEEL":
-        //                strengthArray[0] = materialStringArr[0].Split(null)[2]; ;
-        //                break;
-        //            case "TypeID|TIMBER":
-
-        //                break;
-        //            case "TypeID|ALUMINIUM":
-
-        //                break;
-        //            default:
-        //                break;
-
-        //        }
-
-        //    }
-
-        //    return new double[] { System.Convert.ToDouble(strengthArray[0]) * 1e6, System.Convert.ToDouble(strengthArray[1]) * 1e6 };
-        //}
+        
 
     }
 }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -57,21 +57,17 @@ namespace BH.Adapter.RFEM
                     bhMaterial = Engine.Structure.Create.Aluminium(matName);
                     break;
                 case MaterialType.Steel:
-                    bhMaterial = Engine.Structure.Create.Steel(matName);
+                    double[] matStrenth = getMaterialStrength(material);
+
+                    
+                    bhMaterial = Engine.Structure.Create.Steel(matName,material.ElasticityModulus,material.PoissonRatio,material.ThermalExpansion,material.SpecificWeight,0,matStrenth[0],0);
+
                     break;
                 case MaterialType.Concrete:
-                   // double[] matStrenth=getMaterialStrength(material);
+                     matStrenth=getMaterialStrength(material);
 
-                    double elasticiy = material.ElasticityModulus;
-                    double poisson = material.PoissonRatio;
-                    double thermalEx = material.ThermalExpansion;
-                    double desity = material.SpecificWeight;
-                    double damping = 0;
-                    double cubeStrenght = 0;
-                    double cylinderStrength = 0;
-
-                    //bhMaterial = Engine.Structure.Create.Concrete(matName);
-                    bhMaterial = Engine.Structure.Create.Concrete(matName, elasticiy, poisson, thermalEx, desity, damping, cubeStrenght, cylinderStrength);
+                    
+                    bhMaterial = Engine.Structure.Create.Concrete(matName, material.ElasticityModulus, material.PoissonRatio, material.ThermalExpansion, material.SpecificWeight, 0, matStrenth[1], matStrenth[0]);
 
                     break;
                 case MaterialType.Timber://TODO: as this uses vector over double assumption is the the below turns Timber into an incorrect Isotropic material !!!
@@ -90,52 +86,71 @@ namespace BH.Adapter.RFEM
                     break;
             }
 
-
-            //bhMaterial.Name = material.Comment;
             bhMaterial.Name = matName;
 
             bhMaterial.SetAdapterId(typeof(RFEMId), material.No);
             return bhMaterial;
         }
 
-        //private static double[] getMaterialStrength(rf.Material material)
-        //{
-        //    string[] strengthArray=new string[] {"0","0"};
+        private static double[] getMaterialStrength(rf.Material material)
+        {
+            string[] strengthArray = new string[] { "0", "0" };
 
-        //    if (material.TextID.Equals(""))
-        //    {
+            //Non RFEM Libary Material
+            if (material.TextID.Equals(""))
+            {
 
-                
-                
-        //        //  string[] materialStringArr = material.Description.Split(':');
-        //        //  string materialGradeString = "";
-                
-        //        //    switch (materialStringArr[0])
-        //        //    {
-        //        //    case "CONCRETE":
-        //        //        materialGradeString=materialStringArr[1].Substring(1);
-        //        //        strengthArray = materialGradeString.Split('/');
-        //        //        break;
-        //        //    case "STEEL":
-        //        //        break;
-        //        //    case "TIMBER":
-        //        //        break;
-        //        //    case "ALUMINIUM":
-        //        //        break; 
-        //        //    default:
-        //        //        break;
+                string[] materialStringArr = material.Description.Split(':');
+                string materialGradeString = "";
 
+                switch (materialStringArr[0])
+                {
+                    case "CONCRETE":
+                        materialGradeString = materialStringArr[1].Substring(2);
+                        strengthArray = materialGradeString.Split('/');
+                        break;
+                    case "STEEL":
+                        strengthArray[0] = materialStringArr[1].Substring(2);
+                        break;
+                    case "TIMBER":
+                        break;
+                    case "ALUMINIUM":
+                        break;
+                    default:
+                        break;
 
-        //        //}
+                }
 
+            }// RFEM Libary Material
+            else
+            {
+                string[] materialStringArr = material.TextID.Split('@');
+                string materialGradeString = "";
 
+                switch (materialStringArr[1])
+                {
+                    case "TypeID|CONCRETE":
+                        materialGradeString = materialStringArr[0].Split(null)[1];
+                        strengthArray = materialGradeString.Substring(1).Split('/');
+                        break;
+                    case "TypeID|STEEL":
+                        strengthArray[0] = materialStringArr[0].Split(null)[2]; ;
+                        break;
+                    case "TypeID|TIMBER":
+                       
+                        break;
+                    case "TypeID|ALUMINIUM":
+                      
+                        break;
+                    default:
+                        break;
 
-                
+                }
 
-        //    }
+            }
 
-        //    return new double[] { System.Convert.ToDouble(strengthArray[0])*1e9, System.Convert.ToDouble(strengthArray[1])*1e9};
-        //}
+            return new double[] { System.Convert.ToDouble(strengthArray[0]) * 1e9, System.Convert.ToDouble(strengthArray[1]) * 1e9 };
+        }
 
     }
 }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -45,8 +45,6 @@ namespace BH.Adapter.RFEM
         public static IMaterialFragment FromRFEM(this rf.Material material)
         {
 
-
-
             IMaterialFragment bhMaterial = null;
 
             string[] stringArr = material.TextID.Split('@');
@@ -60,19 +58,19 @@ namespace BH.Adapter.RFEM
                     bhMaterial = Engine.Structure.Create.Aluminium(matName);
                     break;
                 case MaterialType.Steel:
-                   
-                    double yieldStress = (matParaArray.Length>1)?Double.Parse(matParaArray[1]):0;
+
+                    double yieldStress = (matParaArray.Length > 1) ? Double.Parse(matParaArray[1]) : 0;
                     double ulitimateStess = (matParaArray.Length > 1) ? Double.Parse(matParaArray[2]) : 0;
 
-                    bhMaterial = Engine.Structure.Create.Steel(matName, material.ElasticityModulus, material.PoissonRatio, material.ThermalExpansion, material.SpecificWeight*0.1, 0, yieldStress, ulitimateStess);
+                    bhMaterial = Engine.Structure.Create.Steel(matName, material.ElasticityModulus, material.PoissonRatio, material.ThermalExpansion, material.SpecificWeight * 0.1, 0, yieldStress, ulitimateStess);
 
                     break;
                 case MaterialType.Concrete:
-  
+
                     double cylinderStrenth = (matParaArray.Length > 1) ? Double.Parse(matParaArray[1]) : 0;
                     double cubeStrength = (matParaArray.Length > 1) ? Double.Parse(matParaArray[2]) : 0;
 
-                    bhMaterial = Engine.Structure.Create.Concrete(matName, material.ElasticityModulus, material.PoissonRatio, material.ThermalExpansion, material.SpecificWeight * 0.1, 0,cubeStrength, cylinderStrenth);
+                    bhMaterial = Engine.Structure.Create.Concrete(matName, material.ElasticityModulus, material.PoissonRatio, material.ThermalExpansion, material.SpecificWeight * 0.1, 0, cubeStrength, cylinderStrenth);
 
                     break;
                 case MaterialType.Timber://TODO: as this uses vector over double assumption is the the below turns Timber into an incorrect Isotropic material !!!
@@ -158,7 +156,7 @@ namespace BH.Adapter.RFEM
 
         //    return new double[] { System.Convert.ToDouble(strengthArray[0]) * 1e6, System.Convert.ToDouble(strengthArray[1]) * 1e6 };
         //}
-        
+
     }
 }
 

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -110,7 +110,9 @@ namespace BH.Adapter.RFEM
                         strengthArray = materialGradeString.Split('/');
                         break;
                     case "STEEL":
-                        strengthArray[0] = materialStringArr[1].Substring(2);
+                        //Upper boundary for Reading the yield stress from name. Check for Rebar
+                        int upperBoundary = materialStringArr[1].Substring(0,2) == " B" ? materialStringArr[1].Length-3: materialStringArr[1].Length-2;
+                        strengthArray[0] = materialStringArr[1].Substring(2, upperBoundary).Split(null)[0];
                         break;
                     case "TIMBER":
                         break;
@@ -149,7 +151,7 @@ namespace BH.Adapter.RFEM
 
             }
 
-            return new double[] { System.Convert.ToDouble(strengthArray[0]) * 1e9, System.Convert.ToDouble(strengthArray[1]) * 1e9 };
+            return new double[] { System.Convert.ToDouble(strengthArray[0]) * 1e6, System.Convert.ToDouble(strengthArray[1]) * 1e6 };
         }
 
     }

--- a/RFEM_Adapter/Convert/FromRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/Material.cs
@@ -48,8 +48,9 @@ namespace BH.Adapter.RFEM
             IMaterialFragment bhMaterial = null;
 
             string[] stringArr = material.TextID.Split('@');
-            MaterialType matType = material.GetMaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
-            string matName = Engine.Adapters.RFEM.Query.GetMaterialName(material);
+            MaterialType matType = material.MaterialType();// Engine.Adapters.RFEM.Query.GetMaterialType(material);
+            //string matName = Engine.Adapters.RFEM.Query.GetMaterialName(material);
+            string matName = material.TextID == "" ? material.Description.Split(':')[1] : material.Description;
             String[] matParaArray = material.Comment.Split('|');
 
             switch (matType)

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -40,7 +40,8 @@ namespace BH.Adapter.RFEM
      
         public static rf.Material ToRFEM(this IMaterialFragment materialFragment, int materialId)
         {
-            //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
+           
+            //Example: NameID|Beton C30/37@TypeID|CONCRETE@NormID|DIN 1045-1 - 08
 
             rf.Material rfMaterial = new rf.Material();
             rfMaterial.No = materialId;
@@ -53,6 +54,9 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.Description = "ALUMINIUM: " + materialFragment.Name;
+                rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
+                rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | ALUMINIUM" + "@StandardID | No norm set!";
             }
             else if (materialFragment.GetType() == typeof(Steel))
@@ -61,7 +65,12 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+                rfMaterial.Description ="STEEL: "+materialFragment.Name;
+                rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
+                rfMaterial.PartialSafetyFactor = 1.00;
+                rfMaterial.TextID = "NameID | STEEL:" + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+
+               
             }
             else if (materialFragment.GetType() == typeof(Concrete))
             {
@@ -69,7 +78,11 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.Description = "CONCRETE: " + materialFragment.Name;
+                rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
+                rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | CONCRETE" + "@StandardID | No norm set!";
+
 
             }
             else if (materialFragment.GetType() == typeof(GenericIsotropicMaterial))
@@ -78,6 +91,9 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.Description = "ISOTROPIC: " + materialFragment.Name;
+                rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
+                rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
 
             }
@@ -88,6 +104,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
+                rfMaterial.Description = "TIMBER: " + materialFragment.Name;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
 
             }
@@ -97,6 +114,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff.X;
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
+                rfMaterial.Description = "ORTHOTROPIC: " + materialFragment.Name;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
 
             }
@@ -106,8 +124,12 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ThermalExpansion = material.ThermalExpansionCoeff;
                 rfMaterial.PoissonRatio = material.PoissonsRatio;
                 rfMaterial.ElasticityModulus = material.YoungsModulus;
+                rfMaterial.Description = "STEEL: " + materialFragment.Name;
+                rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
+                rfMaterial.PartialSafetyFactor = 1.00;
                 Engine.Base.Compute.RecordWarning("Cannot make " + materialFragment.Name + ". Replaced with standard steel");
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+
 
             }
 

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -58,6 +58,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | ALUMINIUM" + "@StandardID | No norm set!";
+                rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
             }
             else if (materialFragment.GetType() == typeof(Steel))
             {
@@ -69,8 +70,8 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | STEEL:" + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+                rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
 
-               
             }
             else if (materialFragment.GetType() == typeof(Concrete))
             {
@@ -82,7 +83,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | CONCRETE" + "@StandardID | No norm set!";
-
+                rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "CylinderStrength") + "|" + BH.Engine.Base.Query.PropertyValue(material, "CubeStrength");
 
             }
             else if (materialFragment.GetType() == typeof(GenericIsotropicMaterial))
@@ -95,7 +96,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
-
+                rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
             }
             else if (materialFragment.GetType() == typeof(Timber))
             {
@@ -106,7 +107,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
                 rfMaterial.Description = "TIMBER: " + materialFragment.Name;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
-
+                rfMaterial.Comment = materialFragment.Name;
             }
             else if (materialFragment.GetType() == typeof(GenericOrthotropicMaterial))
             {
@@ -116,7 +117,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
                 rfMaterial.Description = "ORTHOTROPIC: " + materialFragment.Name;
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
-
+                rfMaterial.Comment = materialFragment.Name;
             }
             else
             {
@@ -129,11 +130,11 @@ namespace BH.Adapter.RFEM
                 rfMaterial.PartialSafetyFactor = 1.00;
                 Engine.Base.Compute.RecordWarning("Cannot make " + materialFragment.Name + ". Replaced with standard steel");
                 rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
-
+                rfMaterial.Comment = materialFragment.Name;
 
             }
 
-            rfMaterial.Comment = materialFragment.Name;
+            //rfMaterial.Comment = materialFragment.Name;
 
             return rfMaterial;
 

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.RFEM
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
+     
         public static rf.Material ToRFEM(this IMaterialFragment materialFragment, int materialId)
         {
             //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -134,8 +134,6 @@ namespace BH.Adapter.RFEM
 
             }
 
-            //rfMaterial.Comment = materialFragment.Name;
-
             return rfMaterial;
 
         }

--- a/RFEM_Adapter/Convert/ToRFEM/Panel.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Panel.cs
@@ -46,6 +46,7 @@ namespace BH.Adapter.RFEM
             rfSurface.No = panelId;
             rfSurface.GeometryType = rf.SurfaceGeometryType.PlaneSurfaceType;//several other types are available!
             rfSurface.BoundaryLineList = string.Join<int>(",",boundaryIdArr);
+            
             int materialId = panel.Property.Material.AdapterId<int>(typeof(RFEMId));
             rfSurface.MaterialNo = materialId;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -44,8 +44,6 @@ namespace BH.Adapter.RFEM
 
             rf.CrossSection rfSectionProperty = new rf.CrossSection();
 
-
-            //rf.CrossSection rfSectionProperty = new rf.CrossSection();
             string name;
             rfSectionProperty.No = sectionPropertyId;
             rfSectionProperty.MaterialNo = materialId;
@@ -57,12 +55,10 @@ namespace BH.Adapter.RFEM
             rfSectionProperty.BendingMomentZ = sectionProperty.Iz;
 
             name = sectionProperty.DescriptionOrName();
-            
-            
+
             //TODO 
             // The CrossSection class does both use the attribute name and discribtion. 
             // The Grasshopper interface does only know name
-
             rfSectionProperty.Description = name;
             rfSectionProperty.TextID = name;
             rfSectionProperty.Comment = sectionProperty.Name;

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -41,7 +41,11 @@ namespace BH.Adapter.RFEM
 
         public static rf.CrossSection ToRFEM(this ISectionProperty sectionProperty, int sectionPropertyId, int materialId)
         {
+
             rf.CrossSection rfSectionProperty = new rf.CrossSection();
+
+
+            //rf.CrossSection rfSectionProperty = new rf.CrossSection();
             string name;
             rfSectionProperty.No = sectionPropertyId;
             rfSectionProperty.MaterialNo = materialId;

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -47,62 +47,7 @@ namespace BH.Engine.Adapters.RFEM
         //• NormID - Language independent code of the material. 
         //Format: NameID|material ID@TypeID|material type@NormID|material code
         //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
-        [Description("Get list of Ids from RFEM string.")]
-        [Input("rfMaterial", "String with RFEM ids.")]
-        [Output("idList", "List of ids.")]
-        public static MaterialType MaterialType(this rf.Material rfMaterial)
-        {
-            //string[] materialStringArr = rfMaterial.TextID.Split('@');
-
-         
-            //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] :materialStringArr[1].Split('|')[1];
-
-            string materialString = "";
-            string[] materialStringArr;
-
-            if (rfMaterial.Equals(null))
-            {
-                Engine.Base.Compute.RecordWarning("Material was Null and has been set to Steel");
-                return oM.Structure.MaterialFragments.MaterialType.Steel; ; //A suitable return - you could `return null;` here instead if needed
-            }
-            else
-            {
-
-                materialStringArr = rfMaterial.TextID.Split('@');
-                materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] : materialStringArr[1].Split('|')[1];
-            }
-
-
-            switch (materialString)
-            {
-
-                case "TypeID|STEEL":
-                case "STEEL":
-                    return oM.Structure.MaterialFragments.MaterialType.Steel;
-                case "ALUMINIUM":
-                    return oM.Structure.MaterialFragments.MaterialType.Aluminium;
-                case "CONCRETE":
-                    return oM.Structure.MaterialFragments.MaterialType.Concrete;
-                case "TIMBER":
-                case "CONIFEROUS":
-                    return oM.Structure.MaterialFragments.MaterialType.Timber;
-                case "CABLE":
-                    return oM.Structure.MaterialFragments.MaterialType.Cable;
-                case "GLASS":
-                    return oM.Structure.MaterialFragments.MaterialType.Glass;
-                case "TREBAR":
-                    return oM.Structure.MaterialFragments.MaterialType.Rebar;
-                case "TENDON":
-                    return oM.Structure.MaterialFragments.MaterialType.Tendon;
-                default:
-                    Engine.Base.Compute.RecordWarning("Don't know how to make: " + materialString[1]);
-                    return oM.Structure.MaterialFragments.MaterialType.Undefined;
-            }
-
-        }
-
-
-        /***************************************************/
+        
     }
 }
 

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -87,34 +87,7 @@ namespace BH.Engine.Adapters.RFEM
         }
 
 
-        public static string GetMaterialType(IMaterialFragment material)
-        {
-            Type materialType = material.GetType();
-
-            if (materialType == typeof(Aluminium))
-            {
-                return "TypeID|ALUMINIUM";
-            }
-            if (materialType == typeof(Steel))
-            {
-                return "TypeID|STEEL";
-            }
-            if (materialType == typeof(Concrete))
-            {
-                return "TypeID|CONCRETE";
-            }
-            if (materialType == typeof(Timber))
-            {
-                return "TypeID|TIMBER";
-            }
-            else
-            {
-                return null;
-            }
-
-        }
-
-        public static string GetMaterialName(rf.Material rfMaterial)
+        public static string GetMaterialName(this rf.Material rfMaterial)
         {
             //string materialName;
             //string[] materialString = rfMaterial.TextID.Split('@');

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -52,10 +52,26 @@ namespace BH.Engine.Adapters.RFEM
         [Output("idList", "List of ids.")]
         public static MaterialType MaterialType(this rf.Material rfMaterial)
         {
-            string[] materialStringArr = rfMaterial.TextID.Split('@');
+            //string[] materialStringArr = rfMaterial.TextID.Split('@');
 
          
-            string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] :materialStringArr[1].Split('|')[1];
+            //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] :materialStringArr[1].Split('|')[1];
+
+            string materialString = "";
+            string[] materialStringArr;
+
+            if (rfMaterial.Equals(null))
+            {
+                Engine.Base.Compute.RecordWarning("Material was Null and has been set to Steel");
+                return oM.Structure.MaterialFragments.MaterialType.Steel; ; //A suitable return - you could `return null;` here instead if needed
+            }
+            else
+            {
+
+                materialStringArr = rfMaterial.TextID.Split('@');
+                materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] : materialStringArr[1].Split('|')[1];
+            }
+
 
             switch (materialString)
             {

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -47,9 +47,9 @@ namespace BH.Engine.Adapters.RFEM
         //• NormID - Language independent code of the material. 
         //Format: NameID|material ID@TypeID|material type@NormID|material code
         //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
-        [Description("Get list of Ids from RFEM string")]
-        [Input("rfemIdString", "String with RFEM ids")]
-        [Output("idList", "List of ids")]
+        [Description("Get list of Ids from RFEM string.")]
+        [Input("rfMaterial", "String with RFEM ids.")]
+        [Output("idList", "List of ids.")]
         public static MaterialType MaterialType(this rf.Material rfMaterial)
         {
             string[] materialStringArr = rfMaterial.TextID.Split('@');

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -46,16 +46,11 @@ namespace BH.Engine.Adapters.RFEM
         //Format: NameID|material ID@TypeID|material type@NormID|material code
         //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
 
-        public static MaterialType GetMaterialType(this rf.Material rfMaterial)
+        public static MaterialType MaterialType(this rf.Material rfMaterial)
         {
             string[] materialStringArr = rfMaterial.TextID.Split('@');
 
-            //if(materialString.Count()<2)
-            //{
-            //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
-            //    return MaterialType.Steel;
-            //}
-
+         
             string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] :materialStringArr[1].Split('|')[1];
 
             switch (materialString)
@@ -63,53 +58,53 @@ namespace BH.Engine.Adapters.RFEM
 
                 case "TypeID|STEEL":
                 case "STEEL":
-                    return MaterialType.Steel;
+                    return oM.Structure.MaterialFragments.MaterialType.Steel;
                 case "ALUMINIUM":
-                    return MaterialType.Aluminium;
+                    return oM.Structure.MaterialFragments.MaterialType.Aluminium;
                 case "CONCRETE":
-                    return MaterialType.Concrete;
+                    return oM.Structure.MaterialFragments.MaterialType.Concrete;
                 case "TIMBER":
                 case "CONIFEROUS":
-                    return MaterialType.Timber;
+                    return oM.Structure.MaterialFragments.MaterialType.Timber;
                 case "CABLE":
-                    return MaterialType.Cable;
+                    return oM.Structure.MaterialFragments.MaterialType.Cable;
                 case "GLASS":
-                    return MaterialType.Glass;
+                    return oM.Structure.MaterialFragments.MaterialType.Glass;
                 case "TREBAR":
-                    return MaterialType.Rebar;
+                    return oM.Structure.MaterialFragments.MaterialType.Rebar;
                 case "TENDON":
-                    return MaterialType.Tendon;
+                    return oM.Structure.MaterialFragments.MaterialType.Tendon;
                 default:
                     Engine.Base.Compute.RecordWarning("Don't know how to make: " + materialString[1]);
-                    return MaterialType.Undefined;
+                    return oM.Structure.MaterialFragments.MaterialType.Undefined;
             }
 
         }
 
 
-        public static string GetMaterialName(this rf.Material rfMaterial)
-        {
-            //string materialName;
-            //string[] materialString = rfMaterial.TextID.Split('@');
-            //if (materialString.Length < 2)
-            //    materialName = rfMaterial.Description;
-            //else
-            //    materialName = materialString[0].Split('|')[1];
+        //public static string GetMaterialName(this rf.Material rfMaterial)
+        //{
+        //    //string materialName;
+        //    //string[] materialString = rfMaterial.TextID.Split('@');
+        //    //if (materialString.Length < 2)
+        //    //    materialName = rfMaterial.Description;
+        //    //else
+        //    //    materialName = materialString[0].Split('|')[1];
 
-            string[] materialStringArr = rfMaterial.TextID.Split('@');
+        //    string[] materialStringArr = rfMaterial.TextID.Split('@');
 
-            //if(materialString.Count()<2)
-            //{
-            //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
-            //    return MaterialType.Steel;
-            //}
+        //    //if(materialString.Count()<2)
+        //    //{
+        //    //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
+        //    //    return MaterialType.Steel;
+        //    //}
 
-            //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : materialStringArr[1].Split('|')[1];
-            string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : rfMaterial.Description;
+        //    //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : materialStringArr[1].Split('|')[1];
+        //    string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : rfMaterial.Description;
 
 
-            return materialString;
-        }
+        //    return materialString;
+        //}
 
 
         /***************************************************/

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -25,10 +25,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.ComponentModel;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
+using BH.oM.Base.Attributes;
 using rf = Dlubal.RFEM5;
 
 namespace BH.Engine.Adapters.RFEM
@@ -45,7 +47,9 @@ namespace BH.Engine.Adapters.RFEM
         //• NormID - Language independent code of the material. 
         //Format: NameID|material ID@TypeID|material type@NormID|material code
         //Example: NameID|Steel S 235@TypeID|STEEL@StandardID|DIN EN 1993-1-1-10 
-
+        [Description("Get list of Ids from RFEM string")]
+        [Input("rfemIdString", "String with RFEM ids")]
+        [Output("idList", "List of ids")]
         public static MaterialType MaterialType(this rf.Material rfMaterial)
         {
             string[] materialStringArr = rfMaterial.TextID.Split('@');
@@ -80,31 +84,6 @@ namespace BH.Engine.Adapters.RFEM
             }
 
         }
-
-
-        //public static string GetMaterialName(this rf.Material rfMaterial)
-        //{
-        //    //string materialName;
-        //    //string[] materialString = rfMaterial.TextID.Split('@');
-        //    //if (materialString.Length < 2)
-        //    //    materialName = rfMaterial.Description;
-        //    //else
-        //    //    materialName = materialString[0].Split('|')[1];
-
-        //    string[] materialStringArr = rfMaterial.TextID.Split('@');
-
-        //    //if(materialString.Count()<2)
-        //    //{
-        //    //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
-        //    //    return MaterialType.Steel;
-        //    //}
-
-        //    //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : materialStringArr[1].Split('|')[1];
-        //    string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : rfMaterial.Description;
-
-
-        //    return materialString;
-        //}
 
 
         /***************************************************/

--- a/RFEM_Engine/Query/Material.cs
+++ b/RFEM_Engine/Query/Material.cs
@@ -48,32 +48,36 @@ namespace BH.Engine.Adapters.RFEM
 
         public static MaterialType GetMaterialType(this rf.Material rfMaterial)
         {
-            string[] materialString = rfMaterial.TextID.Split('@');
+            string[] materialStringArr = rfMaterial.TextID.Split('@');
 
-            if(materialString.Count()<2)
-            {
-                Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
-                return MaterialType.Steel;
-            }
+            //if(materialString.Count()<2)
+            //{
+            //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
+            //    return MaterialType.Steel;
+            //}
 
-            switch (materialString[1])
+            string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[0] :materialStringArr[1].Split('|')[1];
+
+            switch (materialString)
             {
+
                 case "TypeID|STEEL":
+                case "STEEL":
                     return MaterialType.Steel;
-                case "TypeID|ALUMINIUM":
+                case "ALUMINIUM":
                     return MaterialType.Aluminium;
-                case "TypeID|CONCRETE":
+                case "CONCRETE":
                     return MaterialType.Concrete;
-                case "TypeID|TIMBER":
-                case "TypeID|CONIFEROUS":
+                case "TIMBER":
+                case "CONIFEROUS":
                     return MaterialType.Timber;
-                case "TypeID|CABLE":
+                case "CABLE":
                     return MaterialType.Cable;
-                case "TypeID|GLASS":
+                case "GLASS":
                     return MaterialType.Glass;
-                case "TypeID|REBAR":
+                case "TREBAR":
                     return MaterialType.Rebar;
-                case "TypeID|TENDON":
+                case "TENDON":
                     return MaterialType.Tendon;
                 default:
                     Engine.Base.Compute.RecordWarning("Don't know how to make: " + materialString[1]);
@@ -112,14 +116,26 @@ namespace BH.Engine.Adapters.RFEM
 
         public static string GetMaterialName(rf.Material rfMaterial)
         {
-            string materialName;
-            string[] materialString = rfMaterial.TextID.Split('@');
-            if (materialString.Length < 2)
-                materialName = rfMaterial.Description;
-            else
-                materialName = materialString[0].Split('|')[1];
+            //string materialName;
+            //string[] materialString = rfMaterial.TextID.Split('@');
+            //if (materialString.Length < 2)
+            //    materialName = rfMaterial.Description;
+            //else
+            //    materialName = materialString[0].Split('|')[1];
 
-            return materialName;
+            string[] materialStringArr = rfMaterial.TextID.Split('@');
+
+            //if(materialString.Count()<2)
+            //{
+            //    Engine.Base.Compute.RecordWarning("Don't know how to make" + rfMaterial.TextID + ". Steel created instead!");
+            //    return MaterialType.Steel;
+            //}
+
+            //string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : materialStringArr[1].Split('|')[1];
+            string materialString = rfMaterial.TextID == "" ? rfMaterial.Description.Split(':')[1] : rfMaterial.Description;
+
+
+            return materialString;
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
**Issue 142:**
Push: When Pushing elements into RFEM the type of material is not transfered/generated correctly. The created material that is pused into RFEM does have the same material parameter as the ones defined in the BHoM but is per default alsway assigned as steel. Only the name said concrete (e.g., c x/y). 

Pull: When pulling elements, the material type is recognised correctly (Steel, concrete etc.) however the material grade is not recognised. The material pulled is pulled empty without any parameters

**Expected behaviour - Issue 142:** The materials should be fully recognised by both RFEM and BHoM

**Issue 118:** 
When trying to push bars into an existing RFEM Model (Model already contains sections and materials), an error occurs that causes the bars not to be pushed. Presumably this is due to not being able to pull the sections already existing in the model. this error is not produced when pushing to a newly created model.

**Expected behaviour - Issue 118:** Bars should be pushed into RFEM regardless of the number of Material aready defined in the current RFEM file.  

 Closes #142 
 Closes #118 

 <!-- Add short description of what has been fixed -->
**Issue 142:** 
Main problem was the access to the RFEM material library through the COM interface. Issue has been solved by adding material Information into the materials description and comment. By that the access to the material library were not needed and the necessary material info from the BHoM could be stored. Now all pushed Materials do have a prefix (e.g., STEEL:). The comment does now additionally store information on yielding strength, ultimate strength, cylinder stress or cube stress.


**Issue 118:**
When pushing an element into RFEM previously the material table could cause some errors when not all materials have been enumerated in a gab less series. So as soon as there was an empty row this could have caused an issue. This issue has been solved by iterating over the material list to find a particular material rather than access the material by using a counter. 
Another issue that was causing trouble was the presence of cross sections without any material attached to them. Now all material without any material automatically gets the material 1 of the material table now.


 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Link to test files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/Issue%23118And%23142?csf=1&web=1&e=7zaRHK)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Push Material with correct type and parameters and type
- Pull Material with correct material parameters and type
- Enable push of bars into non empty RFEM project 