### PR TITLE
Push/Pull of non-standard/library sections

### DIFF
--- a/RFEM_Adapter/CRUD/Create/Bar.cs
+++ b/RFEM_Adapter/CRUD/Create/Bar.cs
@@ -69,7 +69,7 @@ namespace BH.Adapter.RFEM
                         var mat= modelData.GetMaterials().Where(k => k.Description.Split(' ')[1].Equals(barMaterialName)).First();
                         int foundMatIndex=modelData.GetMaterials().ToList().IndexOf(mat)+1;
                         rf.CrossSection temporaryCS = barList[i].SectionProperty.ToRFEM( 0, foundMatIndex);
-                        rf.CrossSection matchingCS= modelData.GetCrossSections().ToList().First(c=>c.Description.Equals(temporaryCS.Description)&&c.MaterialNo.Equals(temporaryCS.MaterialNo));
+                        rf.CrossSection matchingCS= modelData.GetCrossSections().ToList().First(c=>(c.Description.Equals(temporaryCS.Description)|| c.Comment.Equals(temporaryCS.Description)) &&c.MaterialNo.Equals(temporaryCS.MaterialNo));
                         rfBars[i].StartCrossSectionNo = matchingCS.No;
 
                     }

--- a/RFEM_Adapter/CRUD/Create/Bar.cs
+++ b/RFEM_Adapter/CRUD/Create/Bar.cs
@@ -59,45 +59,24 @@ namespace BH.Adapter.RFEM
                     centreLine.NodeList = String.Join(",", new int[] { startNodeId, endNodeId });
                     centreLine.Type = rf.LineType.PolylineType;
                     modelData.SetLine(centreLine);
-
-
                     rfBars[i] = barList[i].ToRFEM(barIdNum, lineIdNum);
 
-
-                 
-                    
-                        //if cs does already exist
-
-                      //var crossection= modelData.GetCrossSections().ElementAtOrDefault(rfBars[i].StartCrossSectionNo).Equals(null);
-                       Boolean csAlreadyDefinedPreviously=modelData.GetCrossSections().ElementAtOrDefault(rfBars[i].StartCrossSectionNo-1).TextID == null;
-                    if (csAlreadyDefinedPreviously)
+                    Boolean otherBarIsUsingSameCS=modelData.GetCrossSections().ElementAtOrDefault(rfBars[i].StartCrossSectionNo-1).TextID == null;
+                    if (otherBarIsUsingSameCS)
                     {
-                        //find the equivalent material within the "stock"
+                        //Find right CS Number
                         String barMaterialName = barList[i].SectionProperty.Material.Name;
                         var mat= modelData.GetMaterials().Where(k => k.Description.Split(' ')[1].Equals(barMaterialName)).First();
                         int foundMatIndex=modelData.GetMaterials().ToList().IndexOf(mat)+1;
-                        rf.CrossSection tmpCs = barList[i].SectionProperty.ToRFEM( 0, foundMatIndex);
-                        rf.CrossSection suitedCS= modelData.GetCrossSections().ToList().First(c=>c.Description.Equals(tmpCs.Description)&&c.MaterialNo.Equals(tmpCs.MaterialNo));
-                        rfBars[i].StartCrossSectionNo = suitedCS.No;
+                        rf.CrossSection temporaryCS = barList[i].SectionProperty.ToRFEM( 0, foundMatIndex);
+                        rf.CrossSection matchingCS= modelData.GetCrossSections().ToList().First(c=>c.Description.Equals(temporaryCS.Description)&&c.MaterialNo.Equals(temporaryCS.MaterialNo));
+                        rfBars[i].StartCrossSectionNo = matchingCS.No;
 
                     }
-                        
-                    
-                   
-
-                   
-                    
-                    
-                    
-                    
-
-
-                    //modelData.GetCrossSections().First(c=>c.Description.Equals(rfBars[i].StartCrossSectionNo));
-
+           
                     modelData.SetMember(rfBars[i]);
                 }
 
-                //modelData.SetMembers(rfBars);
             }
 
             return true;

--- a/RFEM_Adapter/CRUD/Create/Bar.cs
+++ b/RFEM_Adapter/CRUD/Create/Bar.cs
@@ -62,6 +62,38 @@ namespace BH.Adapter.RFEM
 
 
                     rfBars[i] = barList[i].ToRFEM(barIdNum, lineIdNum);
+
+
+                 
+                    
+                        //if cs does already exist
+
+                      //var crossection= modelData.GetCrossSections().ElementAtOrDefault(rfBars[i].StartCrossSectionNo).Equals(null);
+                       Boolean csAlreadyDefinedPreviously=modelData.GetCrossSections().ElementAtOrDefault(rfBars[i].StartCrossSectionNo-1).TextID == null;
+                    if (csAlreadyDefinedPreviously)
+                    {
+                        //find the equivalent material within the "stock"
+                        String barMaterialName = barList[i].SectionProperty.Material.Name;
+                        var mat= modelData.GetMaterials().Where(k => k.Description.Split(' ')[1].Equals(barMaterialName)).First();
+                        int foundMatIndex=modelData.GetMaterials().ToList().IndexOf(mat)+1;
+                        rf.CrossSection tmpCs = barList[i].SectionProperty.ToRFEM( 0, foundMatIndex);
+                        rf.CrossSection suitedCS= modelData.GetCrossSections().ToList().First(c=>c.Description.Equals(tmpCs.Description)&&c.MaterialNo.Equals(tmpCs.MaterialNo));
+                        rfBars[i].StartCrossSectionNo = suitedCS.No;
+
+                    }
+                        
+                    
+                   
+
+                   
+                    
+                    
+                    
+                    
+
+
+                    //modelData.GetCrossSections().First(c=>c.Description.Equals(rfBars[i].StartCrossSectionNo));
+
                     modelData.SetMember(rfBars[i]);
                 }
 

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -58,12 +58,12 @@ namespace BH.Adapter.RFEM
                     if (!sectionAlredyInDict)
                     {
                         int maxKey = m_sectionDict.Keys.Count > 0 ? m_sectionDict.Keys.Max():0;
-                        m_sectionDict.Add(maxKey + 1, secList[i]);
+                        m_sectionDict.Add(maxKey +1, secList[i]);
                         rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }
 
-                    rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
+                    //rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                 }
             }
 

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -54,6 +54,7 @@ namespace BH.Adapter.RFEM
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
                     bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
 
+
                     if (!sectionAlredyInDict)
                     {
                         int maxKey = m_sectionDict.Keys.Count > 0 ? m_sectionDict.Keys.Max():0;

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -53,7 +53,8 @@ namespace BH.Adapter.RFEM
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
-                    bool sectionAlredyExistInModel = modelData.GetCrossSections().Any(c => (c.Description.Equals(rfCrossSections[i].Description) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
+                    //bool sectionAlredyExistInModel = modelData.GetCrossSections().Any(c => (c.Description.Equals(rfCrossSections[i].Description) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
+                    bool sectionAlredyExistInModel = modelData.GetCrossSections().Any(c => ((c.Description.Equals(rfCrossSections[i].Description) || (c.Comment.Equals(rfCrossSections[i].Description))) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
 
                     if (!sectionAlredyExistInModel)
                     {

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -54,7 +54,8 @@ namespace BH.Adapter.RFEM
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
 
-                    var sectionAlredyInModel = modelData.GetCrossSections().Any(c => c.TextID.Equals(rfCrossSections[i].TextID));
+                    //  var sectionAlredyInModel = modelData.GetCrossSections().Any(c => c.Description.Equals(rfCrossSections[i].Description));
+                    bool sectionAlredyInModel = modelData.GetCrossSections().Any(c => (c.Description.Equals(rfCrossSections[i].Description) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
 
                    // bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
 

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -52,14 +52,18 @@ namespace BH.Adapter.RFEM
                 {
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
-                    bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
+                    rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
+
+                    var sectionAlredyInModel = modelData.GetCrossSections().Any(c => c.TextID.Equals(rfCrossSections[i].TextID));
+
+                   // bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
 
 
-                    if (!sectionAlredyInDict)
+                    if (!sectionAlredyInModel)
                     {
                         int maxKey = m_sectionDict.Keys.Count > 0 ? m_sectionDict.Keys.Max():0;
                         m_sectionDict.Add(maxKey +1, secList[i]);
-                        rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
+                        //rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }
 

--- a/RFEM_Adapter/CRUD/Create/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Create/SectionProperty.cs
@@ -53,22 +53,14 @@ namespace BH.Adapter.RFEM
                     idNum = GetAdapterId<int>(secList[i]);// NextId(secList[i].GetType()));
                     matNumId = modelData.GetMaterials().ToList().IndexOf(modelData.GetMaterials().ToList().Find(m => m.Description.Split(' ')[1].Equals(secList[i].Material.Name))) + 1;
                     rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
+                    bool sectionAlredyExistInModel = modelData.GetCrossSections().Any(c => (c.Description.Equals(rfCrossSections[i].Description) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
 
-                    //  var sectionAlredyInModel = modelData.GetCrossSections().Any(c => c.Description.Equals(rfCrossSections[i].Description));
-                    bool sectionAlredyInModel = modelData.GetCrossSections().Any(c => (c.Description.Equals(rfCrossSections[i].Description) && c.MaterialNo.Equals(rfCrossSections[i].MaterialNo)));
-
-                   // bool sectionAlredyInDict= m_sectionDict.Values.Any(s => s.Name.Equals(secList[i]));
-
-
-                    if (!sectionAlredyInModel)
+                    if (!sectionAlredyExistInModel)
                     {
                         int maxKey = m_sectionDict.Keys.Count > 0 ? m_sectionDict.Keys.Max():0;
                         m_sectionDict.Add(maxKey +1, secList[i]);
-                        //rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                         modelData.SetCrossSection(rfCrossSections[i]); 
                     }
-
-                    //rfCrossSections[i] = secList[i].ToRFEM(idNum, matNumId);
                 }
             }
 

--- a/RFEM_Adapter/CRUD/Read/SectionProperty.cs
+++ b/RFEM_Adapter/CRUD/Read/SectionProperty.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.RFEM
 
         private List<ISectionProperty> ReadSectionProperties(List<string> ids = null)
         {
-            m_sectionDict.Clear();
+           // m_sectionDict.Clear();
             List<ISectionProperty> sectionPropList = new List<ISectionProperty>();
 
             //ReadSectionFromRFEMLibrary("IPE 200");

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.RFEM
             rfMaterial.No = materialId;
             rfMaterial.Description = materialFragment.Name;
             rfMaterial.SpecificWeight = materialFragment.Density * 10; //translate from kg/m3 to kN/m3
-
+            
             if (materialFragment.GetType() == typeof(Aluminium))
             {
                 IIsotropic material = materialFragment as IIsotropic;

--- a/RFEM_Adapter/Convert/ToRFEM/Material.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/Material.cs
@@ -57,7 +57,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.Description = "ALUMINIUM: " + materialFragment.Name;
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | ALUMINIUM" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | ALUMINIUM" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
             }
             else if (materialFragment.GetType() == typeof(Steel))
@@ -69,7 +69,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.Description ="STEEL: "+materialFragment.Name;
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
-                rfMaterial.TextID = "NameID | STEEL:" + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | STEEL:" + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm!";
                 rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
 
             }
@@ -82,7 +82,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.Description = "CONCRETE: " + materialFragment.Name;
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | CONCRETE" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | CONCRETE" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "CylinderStrength") + "|" + BH.Engine.Base.Query.PropertyValue(material, "CubeStrength");
 
             }
@@ -95,7 +95,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.Description = "ISOTROPIC: " + materialFragment.Name;
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name + "|" + BH.Engine.Base.Query.PropertyValue(material, "YieldStress") + "|" + BH.Engine.Base.Query.PropertyValue(material, "UltimateStress");
             }
             else if (materialFragment.GetType() == typeof(Timber))
@@ -106,7 +106,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
                 rfMaterial.Description = "TIMBER: " + materialFragment.Name;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name;
             }
             else if (materialFragment.GetType() == typeof(GenericOrthotropicMaterial))
@@ -116,7 +116,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.PoissonRatio = material.PoissonsRatio.Y;
                 rfMaterial.ElasticityModulus = material.YoungsModulus.Z;
                 rfMaterial.Description = "ORTHOTROPIC: " + materialFragment.Name;
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | TIMBER" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name;
             }
             else
@@ -129,7 +129,7 @@ namespace BH.Adapter.RFEM
                 rfMaterial.ShearModulus = BH.Engine.Structure.Query.ShearModulus(material);
                 rfMaterial.PartialSafetyFactor = 1.00;
                 Engine.Base.Compute.RecordWarning("Cannot make " + materialFragment.Name + ". Replaced with standard steel");
-                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm set!";
+                rfMaterial.TextID = "NameID | " + materialFragment.Name + "@TypeID | STEEL" + "@StandardID | No norm";
                 rfMaterial.Comment = materialFragment.Name;
 
             }

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -133,7 +133,7 @@ namespace BH.Adapter.RFEM
                             double flangeThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
 
                             prefix = matString.Equals("Steel") ? "IS " : "ITS ";
-                            name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss;
+                            name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss+ "/0";
                             Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
                         }
 
@@ -147,7 +147,7 @@ namespace BH.Adapter.RFEM
                         double webThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
                         double flangeThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
                         prefix = matString.Equals("Steel") ? "TS " : "FB ";
-                        name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness;
+                        name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness +"/0";
                         Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
                         break;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -56,109 +56,106 @@ namespace BH.Adapter.RFEM
 
             name = sectionProperty.DescriptionOrName();
 
+            HashSet<string> standardCSNames = new HashSet<string>() { "HE", "CHS", "IPE", "L", "UPE", "PFC", "RHS", "TUB", "TUC", "UB", "UBP", "UC"};
+                
 
-            String matString=Engine.Base.Query.PropertyValue(sectionProperty, "Material").ToString().Equals("BH.oM.Structure.MaterialFragments.Concrete") ? "Concrete" : "Steel";
-            String shapeString = Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Shape").ToString();
-
-            double diameter, width, height, thickness;
-
-            switch (shapeString)
+            if (!standardCSNames.Contains(sectionProperty.Name.Split(' ')[0]))
             {
-                case "Circle":
 
-                    //if (matString.Equals("Steel"))
-                    //{
-                    //    Engine.Base.Compute.RecordError("Parametrical Circular Steel Section has not Been Implemented!");
-                    //}
 
-                    diameter = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
-                    name = "Circle " + diameter;
+                String matString = Engine.Base.Query.PropertyValue(sectionProperty, "Material").ToString().Equals("BH.oM.Structure.MaterialFragments.Concrete") ? "Concrete" : "Steel";
+                String shapeString = Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Shape").ToString();
 
-                    break;
+                double diameter, width, height, thickness;
 
-                case "Rectangle":
+                switch (shapeString)
+                {
+                    case "Circle":
 
-                    //if (matString.Equals("Steel"))
-                    //{
-                    //    Engine.Base.Compute.RecordError("Parametrical Rectangular Steel Section has not Been Implemented!");
-                    //}
+                        diameter = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
+                        name = "Circle " + diameter;
 
-                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
-                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
-                    name = "Rectangle " + width + "/" + height;
+                        break;
 
-                    break;
+                    case "Rectangle":
 
-                case "Tube":
+                        height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                        width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                        name = "Rectangle " + width + "/" + height;
 
-                    diameter = System.Convert.ToInt32(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
-                    thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
-                    String prefix = matString.Equals("Steel") ? "Pipe " : "Ring ";
-                    name = prefix + diameter + "/" + thickness;
+                        break;
 
-                    break;
+                    case "Tube":
 
-                case "Box":
+                        diameter = System.Convert.ToInt32(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
+                        thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
+                        String prefix = matString.Equals("Steel") ? "Pipe " : "Ring ";
+                        name = prefix + diameter + "/" + thickness;
 
-                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
-                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
-                    thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
-                    if (thickness == 0)
-                    {
-                        thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness"));
-                        Engine.Base.Compute.RecordWarning("Flange Thickness hab been changed to " + thickness + "!");
-                        Engine.Base.Compute.RecordWarning("Weld Size have been ingored!");
-                    }
+                        break;
 
-                    prefix = matString.Equals("Steel") ? "TO " : "HK ";
-                    name = prefix + height + "/" + width + "/" + thickness + "/" + thickness + "/" + thickness + "/" + thickness;
-                    Engine.Base.Compute.RecordWarning("Outer and inner radius of Box profile have been set to 0!");
-                    break;
+                    case "Box":
 
-                case "ISection":
+                        height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                        width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                        thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
+                        if (thickness == 0)
+                        {
+                            thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness"));
+                            Engine.Base.Compute.RecordWarning("Flange Thickness hab been changed to " + thickness + "!");
+                            Engine.Base.Compute.RecordWarning("Weld Size have been ingored!");
+                        }
 
-                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
-                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
-                    //Check if I section symetrical, if not width is not a property and is 0
-                    if (width == 0)
-                    {
-                        double topFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeWidth")) * 1000;
-                        double botFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeWidth")) * 1000;
-                        double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
-                        double topFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeThickness")) * 1000;
-                        double botFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeThickness")) * 1000;
-                        double weldSize = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WeldSize")) * 1000;
-                        name = "IU " + height + "/" + topFlWidth + "/" + topFlThickness + "/" + webThicknesss + "/" + botFlWidth + "/" + botFlThickness + "/" + weldSize + "/" + weldSize;
-                    }
-                    else
-                    {
+                        prefix = matString.Equals("Steel") ? "TO " : "HK ";
+                        name = prefix + height + "/" + width + "/" + thickness + "/" + thickness + "/" + thickness + "/" + thickness;
+                        Engine.Base.Compute.RecordWarning("Outer and inner radius of Box profile have been set to 0!");
+                        break;
 
-                        double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
-                        double flangeThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
+                    case "ISection":
 
-                        prefix = matString.Equals("Steel") ? "IS " : "ITS ";
-                        name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss;
+                        height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                        width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                        //Check if I section symetrical, if not width is not a property and is 0
+                        if (width == 0)
+                        {
+                            double topFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeWidth")) * 1000;
+                            double botFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeWidth")) * 1000;
+                            double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                            double topFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeThickness")) * 1000;
+                            double botFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeThickness")) * 1000;
+                            double weldSize = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WeldSize")) * 1000;
+                            name = "IU " + height + "/" + topFlWidth + "/" + topFlThickness + "/" + webThicknesss + "/" + botFlWidth + "/" + botFlThickness + "/" + weldSize + "/" + weldSize;
+                        }
+                        else
+                        {
+
+                            double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                            double flangeThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
+
+                            prefix = matString.Equals("Steel") ? "IS " : "ITS ";
+                            name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss;
+                            Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
+                        }
+
+                        break;
+
+
+                    case "Tee":
+
+                        height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                        width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                        double webThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                        double flangeThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
+                        prefix = matString.Equals("Steel") ? "TS " : "FB ";
+                        name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness;
                         Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
-                    }
+                        break;
 
-                    break;
+                    default:
 
-
-                case "Tee":
-
-                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
-                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
-                    double webThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
-                    double flangeThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
-                    prefix = matString.Equals("Steel") ? "TS " : "FB ";
-                    name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness;
-                    Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
-                    break;
-
-                default:
-
-                    name = sectionProperty.DescriptionOrName();
-                    break;
+                        name = sectionProperty.DescriptionOrName();
+                        break;
+                }
             }
 
             //TODO 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -56,6 +56,111 @@ namespace BH.Adapter.RFEM
 
             name = sectionProperty.DescriptionOrName();
 
+
+            String matString=Engine.Base.Query.PropertyValue(sectionProperty, "Material").ToString().Equals("BH.oM.Structure.MaterialFragments.Concrete") ? "Concrete" : "Steel";
+            String shapeString = Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Shape").ToString();
+
+            double diameter, width, height, thickness;
+
+            switch (shapeString)
+            {
+                case "Circle":
+
+                    if (matString.Equals("Steel"))
+                    {
+                        Engine.Base.Compute.RecordError("Parametrical Circular Steel Section has not Been Implemented!");
+                    }
+
+                    diameter = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
+                    name = "Circle " + diameter;
+
+                    break;
+
+                case "Rectangle":
+
+                    if (matString.Equals("Steel"))
+                    {
+                        Engine.Base.Compute.RecordError("Parametrical Rectangular Steel Section has not Been Implemented!");
+                    }
+
+                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                    name = "Rectangle " + width + "/" + height;
+
+                    break;
+
+                case "Tube":
+
+                    diameter = System.Convert.ToInt32(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
+                    thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
+                    String prefix = matString.Equals("Steel") ? "Pipe " : "Ring ";
+                    name = prefix + diameter + "/" + thickness;
+
+                    break;
+
+                case "Box":
+
+                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                    thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Thickness")) * 1000;
+                    if (thickness == 0)
+                    {
+                        thickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness"));
+                        Engine.Base.Compute.RecordWarning("Flange Thickness hab been changed to " + thickness + "!");
+                        Engine.Base.Compute.RecordWarning("Weld Size have been ingored!");
+                    }
+
+                    prefix = matString.Equals("Steel") ? "TO " : "HK ";
+                    name = prefix + height + "/" + width + "/" + thickness + "/" + thickness + "/" + thickness + "/" + thickness;
+                    Engine.Base.Compute.RecordWarning("Outer and inner radius of Box profile have been set to 0!");
+                    break;
+
+                case "ISection":
+
+                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                    //Check if I section symetrical, if not width is not a property and is 0
+                    if (width == 0)
+                    {
+                        double topFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeWidth")) * 1000;
+                        double botFlWidth = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeWidth")) * 1000;
+                        double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                        double topFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.TopFlangeThickness")) * 1000;
+                        double botFlThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.BotFlangeThickness")) * 1000;
+                        double weldSize = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WeldSize")) * 1000;
+                        name = "IU " + height + "/" + topFlWidth + "/" + topFlThickness + "/" + webThicknesss + "/" + botFlWidth + "/" + botFlThickness + "/" + weldSize + "/" + weldSize;
+                    }
+                    else
+                    {
+
+                        double webThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                        double flangeThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
+
+                        prefix = matString.Equals("Steel") ? "IS " : "ITS ";
+                        name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss;
+                        Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
+                    }
+
+                    break;
+
+
+                case "Tee":
+
+                    height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
+                    width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;
+                    double webThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
+                    double flangeThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
+                    prefix = matString.Equals("Steel") ? "TS " : "FB ";
+                    name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness;
+                    Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
+                    break;
+
+                default:
+
+                    name = sectionProperty.DescriptionOrName();
+                    break;
+            }
+
             //TODO 
             // The CrossSection class does both use the attribute name and discribtion. 
             // The Grasshopper interface does only know name

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -66,10 +66,10 @@ namespace BH.Adapter.RFEM
             {
                 case "Circle":
 
-                    if (matString.Equals("Steel"))
-                    {
-                        Engine.Base.Compute.RecordError("Parametrical Circular Steel Section has not Been Implemented!");
-                    }
+                    //if (matString.Equals("Steel"))
+                    //{
+                    //    Engine.Base.Compute.RecordError("Parametrical Circular Steel Section has not Been Implemented!");
+                    //}
 
                     diameter = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Diameter")) * 1000;
                     name = "Circle " + diameter;
@@ -78,10 +78,10 @@ namespace BH.Adapter.RFEM
 
                 case "Rectangle":
 
-                    if (matString.Equals("Steel"))
-                    {
-                        Engine.Base.Compute.RecordError("Parametrical Rectangular Steel Section has not Been Implemented!");
-                    }
+                    //if (matString.Equals("Steel"))
+                    //{
+                    //    Engine.Base.Compute.RecordError("Parametrical Rectangular Steel Section has not Been Implemented!");
+                    //}
 
                     height = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000;
                     width = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000;

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -94,13 +94,14 @@ namespace BH.Engine.Adapters.RFEM
                     case "UBP":
                     case "UC":
                     case "HD":
+                    case "IU":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
+                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, 0.1, 0.1);
                         break;
                     case "IS"://parametric
                     case "ITS":
@@ -126,6 +127,7 @@ namespace BH.Engine.Adapters.RFEM
                     case "TO"://parametric
                     case "HSH":
                     case "HSV":
+                    case "HK":
                         v1 = sectionDBProps[0].fValue;
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -101,7 +101,7 @@ namespace BH.Engine.Adapters.RFEM
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, 0.1, 0.1);
+                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
                         break;
                     case "IS"://parametric
                     case "ITS":
@@ -149,7 +149,7 @@ namespace BH.Engine.Adapters.RFEM
                         v1 = sectionDBProps[0].fValue;
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
-                        profile = Spatial.Create.RectangleProfile(v1, v2, v3);
+                        profile = Spatial.Create.RectangleProfile(v1, v2, 0);
                         break;
 
                     case "L":

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -94,14 +94,24 @@ namespace BH.Engine.Adapters.RFEM
                     case "UBP":
                     case "UC":
                     case "HD":
-                    case "IU":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                         v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;
                         v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_s).fValue;
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
+                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, 0.1, 0.1);
+                        break;
+                    case "IU":
+                        v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
+                        v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_bo).fValue;
+                        v3 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_to).fValue;
+                        v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
+                        v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_bu).fValue;
+                        v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_tu).fValue;
+                        //profile = Spatial.Create.FabricatedISectionProfile(v1, v2, v4, v3, v5, v6);
+                        //profile = Spatial.Create.FabricatedISectionProfile(1, 1.5, 2, 0.1, 0.1, 0.1);
+                        profile = Spatial.Create.FabricatedISectionProfile(v1, v2, v5, v4, v3, v6);
                         break;
                     case "IS"://parametric
                     case "ITS":

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -100,7 +100,7 @@ namespace BH.Engine.Adapters.RFEM
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_t_g).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_r_1).fValue;
-                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, 0.1, 0.1);
+                        profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, v5, v6);
                         break;
                     case "IU":
                         v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -109,8 +109,6 @@ namespace BH.Engine.Adapters.RFEM
                         v4 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_s).fValue;
                         v5 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_bu).fValue;
                         v6 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_tu).fValue;
-                        //profile = Spatial.Create.FabricatedISectionProfile(v1, v2, v4, v3, v5, v6);
-                        //profile = Spatial.Create.FabricatedISectionProfile(1, 1.5, 2, 0.1, 0.1, 0.1);
                         profile = Spatial.Create.FabricatedISectionProfile(v1, v2, v5, v4, v3, v6);
                         break;
                     case "IS"://parametric
@@ -121,8 +119,6 @@ namespace BH.Engine.Adapters.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        //v5 = sectionDBProps[4].fValue;
-                        //v6 = sectionDBProps[5].fValue;
                         profile = Spatial.Create.ISectionProfile(v1, v2, v3, v4, 0, 0);
                         break;
                     case "SHS":
@@ -183,8 +179,6 @@ namespace BH.Engine.Adapters.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        //v5 = sectionDBProps[4].fValue;
-                        //v6 = sectionDBProps[5].fValue;
                         profile = Spatial.Create.AngleProfile(v1, v2, v3, v4, 0, 0);
                         break;
 
@@ -207,8 +201,6 @@ namespace BH.Engine.Adapters.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        //v5 = sectionDBProps[4].fValue;
-                        //v6 = sectionDBProps[5].fValue;
                         profile = Spatial.Create.TSectionProfile(v1, v2, v3, v4, 0, 0);
                         break;
 
@@ -235,8 +227,6 @@ namespace BH.Engine.Adapters.RFEM
                         v2 = sectionDBProps[1].fValue;
                         v3 = sectionDBProps[2].fValue;
                         v4 = sectionDBProps[3].fValue;
-                        //v5 = sectionDBProps[4].fValue;
-                        //v6 = sectionDBProps[5].fValue;
                         profile = Spatial.Create.ChannelProfile(v1, v2, v3, v4, 0, 0);
                         break;
                     case "CHS":


### PR DESCRIPTION
 ### Issues addressed by this PR
When pushing a non-standard section from BHoM to RFEM they are not correctly recognized as parametric cross-sections.

When pulling a SectionProperty from RFEM it defaults to an ExpliciteSection if the section name cannot be found in the library.
 
 Closes #151 
 Closes #95  


 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
A test file can be found under the following [Link](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/[Issue151_Issue95](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RFEM_Toolkit/Issue151_Issue95?csf=1&web=1&e=6zX5pP)?csf=1&web=1&e=6zX5pP)

There are two expected outcomes of this test file.
1. When pushing the defined bars into RFEM all bars should be occur with the right material and the correct cross-sections. Bars with identical sections should reference the same sections.
2. When pulling the bars all bars should reference the correct sections and non of them should be explicit.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Enable the push of Parametric steel and concrete sections from the BHoM into RFEM by translating the. This includes BHoM sections of type:

  1. Circle
  3. Rectangel
  4. Tube
  5. Box
  6. ISection
  7. Tee

- Making sure that when multiple beams with an identical section are pushed they do all reference the same section rather than defining a new section for every beam.

- When pulling non-library sections of the previously mentioned type they are recognized as non-explicit cross-sections.

 ### Additional comments
<!-- As required -->
When pushing the bars all bars should have assigned the correct sections plus materials to them. However, in RFEM the colorization of the materials will all look the same. So it is not possible to distinguish between different materials by the mere appearance
