### PR TITLE
Push and Pull of Parametric Sections and Beams

### DIFF
--- a/RFEM_Adapter/CRUD/Read/Node.cs
+++ b/RFEM_Adapter/CRUD/Read/Node.cs
@@ -46,6 +46,7 @@ namespace BH.Adapter.RFEM
         private List<Node> ReadNodes(List<string> ids = null)
         {
 
+
             List<Node> nodeList = new List<Node>();
 
             if (ids == null)

--- a/RFEM_Adapter/Comparers/RFEMSectionComparer.cs
+++ b/RFEM_Adapter/Comparers/RFEMSectionComparer.cs
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Physical.Materials;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SectionProperties;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.RFEM;
+using rf = Dlubal.RFEM5;
+
+namespace BH.Adapter.RFEM
+{
+    public class RFEMSectionComparer : IEqualityComparer<ISectionProperty>
+    {
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public RFEMSectionComparer()
+        {
+
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public bool Equals(ISectionProperty section1, ISectionProperty section2)
+        {
+            //Check whether the compared objects reference the same data.
+            if (Object.ReferenceEquals(section1, section2)) return true;
+
+            //Check whether any of the compared objects is null.
+            if (Object.ReferenceEquals(section1, null) || Object.ReferenceEquals(section2, null))
+                return false;
+
+            string sectionName1=Convert.RFEMSectionName(section1);
+            string sectionName2 = Convert.RFEMSectionName(section2);
+
+            if (sectionName1.Equals(sectionName2) && section1.Material.Name.Equals(section2.Material.Name)) return true;
+
+
+            return false;
+
+        }
+
+        /***************************************************/
+
+        public int GetHashCode(ISectionProperty section)
+        {
+            return 0;
+        }
+
+
+        /***************************************************/
+
+
+    }
+
+}
+
+
+

--- a/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/FromRFEM/SectionProperty.cs
@@ -51,11 +51,8 @@ namespace BH.Adapter.RFEM
 
             string sectionName = rfSectionProperty.Description;
 
-            
-
-
-
             rf3.DB_CRSC_PROPERTY[] sectionDBProps = null;
+
             object libraryObj = null;
 
             if (sectionName != "")

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -54,10 +54,29 @@ namespace BH.Adapter.RFEM
             rfSectionProperty.BendingMomentY = sectionProperty.Iy;
             rfSectionProperty.BendingMomentZ = sectionProperty.Iz;
 
+
+            name = RFEMSectionName(sectionProperty);
+
+            rfSectionProperty.Description = name;
+            rfSectionProperty.TextID = name;
+            rfSectionProperty.Comment = sectionProperty.Name;
+
+            return rfSectionProperty;
+
+        }
+
+        public static string RFEMSectionName (this ISectionProperty sectionProperty)
+        {
+
+            //rf.CrossSection rfSectionProperty = new rf.CrossSection();
+
+            string name;
+            
+
             name = sectionProperty.DescriptionOrName();
 
-            HashSet<string> standardCSNames = new HashSet<string>() { "HE", "CHS", "IPE", "L", "UPE", "PFC", "RHS", "TUB", "TUC", "UB", "UBP", "UC"};
-                
+            HashSet<string> standardCSNames = new HashSet<string>() { "HE", "CHS", "IPE", "L", "UPE", "PFC", "RHS", "TUB", "TUC", "UB", "UBP", "UC" };
+
 
             if (!standardCSNames.Contains(sectionProperty.Name.Split(' ')[0]))
             {
@@ -160,14 +179,24 @@ namespace BH.Adapter.RFEM
                 }
             }
 
+            if (sectionProperty.Name.Split(' ')[0].Equals("L")) {
+
+                int h = (int)(System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Height")) * 1000);
+                int b = (int)(System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.Width")) * 1000);
+                int t = (int)(System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000);
+
+                name = "L " + h + "x" + b + "x" + t;
+
+            }
+
             //TODO 
             // The CrossSection class does both use the attribute name and discribtion. 
             // The Grasshopper interface does only know name
-            rfSectionProperty.Description = name;
-            rfSectionProperty.TextID = name;
-            rfSectionProperty.Comment = sectionProperty.Name;
+            //rfSectionProperty.Description = name;
+            //rfSectionProperty.TextID = name;
+            //rfSectionProperty.Comment = sectionProperty.Name;
 
-            return rfSectionProperty;
+            return name;
 
         }
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -133,7 +133,8 @@ namespace BH.Adapter.RFEM
                             double flangeThicknesss = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
 
                             prefix = matString.Equals("Steel") ? "IS " : "ITS ";
-                            name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss+ "/0";
+                            name = prefix + height + "/" + width + "/" + webThicknesss + "/" + flangeThicknesss;
+                            name = prefix.Equals("IS ") ? name + "/0" : name;
                             Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
                         }
 
@@ -147,7 +148,8 @@ namespace BH.Adapter.RFEM
                         double webThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.WebThickness")) * 1000;
                         double flangeThickness = System.Convert.ToDouble(Engine.Base.Query.PropertyValue(sectionProperty, "SectionProfile.FlangeThickness")) * 1000;
                         prefix = matString.Equals("Steel") ? "TS " : "FB ";
-                        name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness +"/0";
+                        name = prefix + height + "/" + width + "/" + webThickness + "/" + flangeThickness;
+                        name = prefix.Equals("TS ") ? name + "/0" : name;
                         Engine.Base.Compute.RecordWarning("Root and toe radius of the ISection have been set to 0!");
                         break;
 

--- a/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
+++ b/RFEM_Adapter/Convert/ToRFEM/SectionProperty.cs
@@ -188,7 +188,19 @@ namespace BH.Adapter.RFEM
                 name = "L " + h + "x" + b + "x" + t;
 
             }
+            if (sectionProperty.Name.Split(' ')[0].Equals("TUB")) {
 
+                string dimensions=sectionProperty.Name.Split(' ')[1];
+
+                name=string.Concat("1/2 UB ", dimensions);
+            }
+            if (sectionProperty.Name.Split(' ')[0].Equals("TUC"))
+            {
+
+                string dimensions = sectionProperty.Name.Split(' ')[1];
+
+                name = string.Concat("1/2 UC ", dimensions);
+            }
             //TODO 
             // The CrossSection class does both use the attribute name and discribtion. 
             // The Grasshopper interface does only know name

--- a/RFEM_Adapter/RFEMAdapter.cs
+++ b/RFEM_Adapter/RFEMAdapter.cs
@@ -75,7 +75,7 @@ namespace BH.Adapter.RFEM
             {
                 {typeof(Bar), new BH.Engine.Structure.BarEndNodesDistanceComparer(3) },
                 {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },
-                {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
+                {typeof(ISectionProperty), new RFEMSectionComparer() },
                 {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
                 {typeof(LinkConstraint), new BHoMObjectNameComparer() },
                 //{typeof(Panel), new BHoMObjectNameComparer() },

--- a/RFEM_Adapter/RFEM_Adapter.csproj
+++ b/RFEM_Adapter/RFEM_Adapter.csproj
@@ -147,6 +147,7 @@
   <ItemGroup>
     <Compile Include="AdapterActions\Pull.cs" />
     <Compile Include="AdapterActions\Push.cs" />
+    <Compile Include="Comparers\RFEMSectionComparer.cs" />
     <Compile Include="Convert\FromRFEM\Bar.cs" />
     <Compile Include="Convert\FromRFEM\Constraint.cs" />
     <Compile Include="Convert\FromRFEM\Load\BarUniformlyDistributed.cs" />
@@ -213,6 +214,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/RFEM_Engine/Compute/Profile.cs
+++ b/RFEM_Engine/Compute/Profile.cs
@@ -27,6 +27,8 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Base;
+using BH.Engine;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Spatial.ShapeProfiles;
 using rf = Dlubal.RFEM5;
@@ -254,7 +256,26 @@ namespace BH.Engine.Adapters.RFEM
                         profile = Spatial.Create.CircleProfile(v1);
                         break;
 
-                    //case "Z":
+                    case "1/2":
+
+                        //string rfSecName_simplified = profileNameArr[1].Equals("UB") ? " TUB " : " TUC ";
+
+                       
+                        if (profileNameArr[1] == "UC")
+                        {
+                            var parArr=profileNameArr[2].Split('x');
+                            profile = Spatial.Create.TSectionProfile(sectionDBProps[0].fValue, sectionDBProps[1].fValue, sectionDBProps[2].fValue, sectionDBProps[3].fValue, sectionDBProps[3].fValue, sectionDBProps[4].fValue);
+                        }
+                        else if (profileNameArr[1] == "UB") 
+                        {
+                            var parArr = profileNameArr[2].Split('x');
+                            profile = Spatial.Create.TSectionProfile(sectionDBProps[0].fValue, sectionDBProps[1].fValue, sectionDBProps[2].fValue, sectionDBProps[3].fValue, sectionDBProps[3].fValue, sectionDBProps[4].fValue);
+                        }
+                        else Engine.Base.Compute.RecordError("Don't know how to make profile: " + profileName);
+
+
+
+                        break;
                     //case "KZ":
                     //    v1 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_h).fValue;
                     //    v2 = sectionDBProps.FirstOrDefault(x => x.ID == rf3.DB_CRSC_PROPERTY_ID.CRSC_PROP_b).fValue;


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
During the pushing process of multiple beams with different cross-sections, they were mistakenly pushed as multiple beams with equal cross-sections. Furthermore, there were issues with correctly pushing beams that had a T-shaped section. Standard L-shaped beams could not be pushed at all.

 Closes #160 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File Bar Push/Pull](https://burohappold-my.sharepoint.com/:u:/r/personal/arne_martensen_burohappold_com/Documents/Documents/RFEM5/TestScripts/PushPullBars.gh?csf=1&web=1&e=C3Ukyk)
[Test File Section Push/Pull](https://burohappold-my.sharepoint.com/:u:/r/personal/arne_martensen_burohappold_com/Documents/Documents/RFEM5/TestScripts/PushPullSections_TestFile%20(1).gh?csf=1&web=1&e=EQXEhQ)
 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added A Customized Comparator to compare BHoM Sections
- Modified the reading writing of L-Sections


